### PR TITLE
Keep-alive data support & Server acceptor setup rejection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ private fun handler(setup: Setup, rSocket: RSocket): Single<RSocket> {
 ### LICENSE
 
 Copyright 2015-2018 Netflix, Inc.
-Maksym Ostroverkhov
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/ClientOptions.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/ClientOptions.kt
@@ -1,0 +1,7 @@
+package io.rsocket.kotlin
+
+class ClientOptions : Options<ClientOptions>() {
+
+    override fun copy(): ClientOptions =
+            ClientOptions().streamRequestLimit(streamRequestLimit())
+}

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/Duration.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/Duration.kt
@@ -2,10 +2,6 @@ package io.rsocket.kotlin
 
 import java.util.concurrent.TimeUnit
 
-/**
- * Created by Maksym Ostroverkhov on 27.10.17.
- */
-
 data class Duration(private val value: Long, val unit: TimeUnit) {
 
     val millis = unit.toMillis(value)

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/KeepAliveData.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/KeepAliveData.kt
@@ -1,0 +1,11 @@
+package io.rsocket.kotlin
+
+import java.nio.ByteBuffer
+
+interface KeepAliveData {
+
+    fun producer(): () -> ByteBuffer
+
+    fun handler(): (ByteBuffer) -> Unit
+}
+

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/KeepAliveOptions.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/KeepAliveOptions.kt
@@ -1,8 +1,11 @@
 package io.rsocket.kotlin
 
+import io.rsocket.kotlin.internal.EmptyKeepAliveData
+
 class KeepAliveOptions : KeepAlive {
     private var interval: Duration = Duration.ofMillis(100)
     private var maxLifeTime: Duration = Duration.ofSeconds(1)
+    private var keepAliveData: KeepAliveData = EmptyKeepAliveData()
 
     fun keepAliveInterval(interval: Duration): KeepAliveOptions {
         assertDuration(interval, "keepAliveInterval")
@@ -20,9 +23,17 @@ class KeepAliveOptions : KeepAlive {
 
     override fun keepAliveMaxLifeTime() = maxLifeTime
 
+    fun keepAliveData(keepAliveData: KeepAliveData): KeepAliveOptions {
+        this.keepAliveData = keepAliveData
+        return this
+    }
+
+    fun keepAliveData(): KeepAliveData = keepAliveData
+
     fun copy(): KeepAliveOptions = KeepAliveOptions()
             .keepAliveInterval(interval)
             .keepAliveMaxLifeTime(maxLifeTime)
+            .keepAliveData(keepAliveData)
 
     private fun assertDuration(duration: Duration, name: String) {
         if (duration.millis <= 0) {

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/Options.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/Options.kt
@@ -1,0 +1,22 @@
+package io.rsocket.kotlin
+
+abstract class Options<T:Options<T>> internal constructor() {
+    private var streamRequestLimit: Int = 128
+
+    @Suppress("UNCHECKED_CAST")
+    open fun streamRequestLimit(streamRequestLimit: Int): T {
+        assertRequestLimit(streamRequestLimit)
+        this.streamRequestLimit = streamRequestLimit
+        return this as T
+    }
+
+    abstract fun copy(): T
+
+    internal fun streamRequestLimit(): Int = streamRequestLimit
+
+    private fun assertRequestLimit(streamRequestLimit: Int) {
+        if (streamRequestLimit <= 0) {
+            throw IllegalArgumentException("stream request limit must be positive")
+        }
+    }
+}

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/ServerOptions.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/ServerOptions.kt
@@ -1,0 +1,7 @@
+package io.rsocket.kotlin
+
+class ServerOptions : Options<ServerOptions>() {
+
+    override fun copy(): ServerOptions =
+            ServerOptions().streamRequestLimit(streamRequestLimit())
+}

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/EmptyKeepAliveData.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/EmptyKeepAliveData.kt
@@ -1,0 +1,17 @@
+package io.rsocket.kotlin.internal
+
+import io.rsocket.kotlin.KeepAliveData
+import java.nio.ByteBuffer
+
+internal class EmptyKeepAliveData : KeepAliveData {
+
+    override fun producer(): () -> ByteBuffer = noopProducer
+
+    override fun handler(): (ByteBuffer) -> Unit = noopHandler
+
+    companion object {
+        private val emptyBuffer = ByteBuffer.allocateDirect(0)
+        private val noopProducer = { emptyBuffer }
+        private val noopHandler: (ByteBuffer) -> Unit = { }
+    }
+}

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
@@ -21,14 +21,12 @@ import io.reactivex.Flowable
 import io.reactivex.FlowableSubscriber
 import io.reactivex.Single
 import io.reactivex.processors.FlowableProcessor
-import io.reactivex.processors.PublishProcessor
 import io.reactivex.processors.UnicastProcessor
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.exceptions.ApplicationException
 import io.rsocket.kotlin.exceptions.ChannelRequestException
 import io.rsocket.kotlin.exceptions.Exceptions
 import io.rsocket.kotlin.internal.ExceptionUtil.noStacktrace
-import io.rsocket.kotlin.DefaultPayload
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -113,7 +111,7 @@ internal class RSocketRequester(
             val requestFrame = Frame.Request.from(
                     streamId, FrameType.REQUEST_RESPONSE, payload, 1)
 
-            val receiver = PublishProcessor.create<Payload>()
+            val receiver = UnicastProcessor.create<Payload>()
             receivers[streamId] = receiver
             sentFrames.onNext(requestFrame)
 

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/RejectingRSocket.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/RejectingRSocket.kt
@@ -1,0 +1,18 @@
+package io.rsocket.kotlin.internal
+
+import io.reactivex.Single
+import io.rsocket.kotlin.DuplexConnection
+import io.rsocket.kotlin.Frame
+import io.rsocket.kotlin.RSocket
+import io.rsocket.kotlin.exceptions.RejectedSetupException
+
+internal class RejectingRSocket(private val rSocket: Single<RSocket>) {
+
+    fun with(connection: DuplexConnection): Single<RSocket> = rSocket
+            .onErrorResumeNext { err ->
+                connection
+                        .sendOne(Frame.Error.from(0,
+                                RejectedSetupException(err.message ?: "")))
+                        .andThen(Single.error(err))
+            }
+}

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/ServerServiceHandler.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/ServerServiceHandler.kt
@@ -6,11 +6,11 @@ import io.reactivex.Flowable
 import io.reactivex.disposables.Disposable
 import io.rsocket.kotlin.DuplexConnection
 import io.rsocket.kotlin.Frame
-import io.rsocket.kotlin.exceptions.ConnectionException
 import io.rsocket.kotlin.KeepAlive
+import io.rsocket.kotlin.exceptions.ConnectionException
 import java.util.concurrent.TimeUnit
 
-internal class ServerServiceHandler(serviceConnection: DuplexConnection,
+internal class ServerServiceHandler(private val serviceConnection: DuplexConnection,
                                     keepAlive: KeepAlive,
                                     errorConsumer: (Throwable) -> Unit)
     : ServiceHandler(serviceConnection, errorConsumer) {
@@ -22,7 +22,7 @@ internal class ServerServiceHandler(serviceConnection: DuplexConnection,
     init {
         val tickPeriod = keepAlive.keepAliveInterval().millis
         val timeout = keepAlive.keepAliveMaxLifeTime().millis
-        Flowable.interval(tickPeriod, TimeUnit.MILLISECONDS)
+        subscription = Flowable.interval(tickPeriod, TimeUnit.MILLISECONDS)
                 .concatMapCompletable { checkKeepAlive(timeout) }
                 .subscribe({},
                         { err ->

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/ConnectionLeaseRef.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/ConnectionLeaseRef.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.reactivex.Completable

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseContext.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseContext.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 /** State shared by Lease related interceptors  */

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseEnablingInterceptor.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseEnablingInterceptor.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.reactivex.Flowable

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranter.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.reactivex.Completable

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranterConnection.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranterConnection.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.netty.buffer.Unpooled

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranterInterceptor.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranterInterceptor.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.rsocket.kotlin.DuplexConnection

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseInterceptor.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseInterceptor.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.rsocket.kotlin.RSocket

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseManager.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseManager.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.rsocket.kotlin.exceptions.MissingLeaseException

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseRSocket.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseRSocket.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.reactivex.Completable

--- a/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseSupport.kt
+++ b/rsocket-core/src/main/kotlin/io/rsocket/kotlin/internal/lease/LeaseSupport.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Maksym Ostroverkhov
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 package io.rsocket.kotlin.internal.lease
 
 import io.rsocket.kotlin.LeaseRef

--- a/rsocket-core/src/test/kotlin/io/rsocket/kotlin/internal/RejectingRSocketTest.kt
+++ b/rsocket-core/src/test/kotlin/io/rsocket/kotlin/internal/RejectingRSocketTest.kt
@@ -1,0 +1,55 @@
+package io.rsocket.kotlin.internal
+
+import io.reactivex.Single
+import io.reactivex.processors.UnicastProcessor
+import io.rsocket.kotlin.Frame
+import io.rsocket.kotlin.FrameType
+import io.rsocket.kotlin.RSocket
+import io.rsocket.kotlin.exceptions.Exceptions
+import io.rsocket.kotlin.exceptions.RejectedSetupException
+import io.rsocket.kotlin.test.util.LocalDuplexConnection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RejectingRSocketTest {
+    private lateinit var sender: UnicastProcessor<Frame>
+    private lateinit var receiver: UnicastProcessor<Frame>
+    private lateinit var conn: LocalDuplexConnection
+
+    @Before
+    fun setUp() {
+        sender = UnicastProcessor.create<Frame>()
+        receiver = UnicastProcessor.create<Frame>()
+        conn = LocalDuplexConnection("test", sender, receiver)
+    }
+
+    @Test(timeout = 2_000)
+    fun rejectError() {
+        val expectedMsg = "error"
+        val rejectingRSocket = rejectingRSocket(IllegalArgumentException(expectedMsg))
+        rejectingRSocket.subscribe({}, {})
+        val frame = sender.firstOrError().blockingGet()
+        assertTrue(frame.type == FrameType.ERROR)
+        assertTrue(frame.streamId == 0)
+        val err = Exceptions.from(frame)
+        assertTrue(err is RejectedSetupException)
+        assertEquals(expectedMsg, err.message)
+    }
+
+    @Test(timeout = 2_000)
+    fun rejectErrorEmptyMessage() {
+        val rejectingRSocket = rejectingRSocket(RuntimeException())
+        rejectingRSocket.subscribe({}, {})
+        val frame = sender.firstOrError().blockingGet()
+        val err = Exceptions.from(frame)
+        assertTrue(err is RejectedSetupException)
+        assertEquals("", err.message)
+    }
+
+    private fun rejectingRSocket(err: Throwable): Single<RSocket> {
+        val rSocket = Single.error<RSocket>(err)
+        return RejectingRSocket(rSocket).with(conn)
+    }
+}

--- a/rsocket-core/src/test/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranterConnectionTest.kt
+++ b/rsocket-core/src/test/kotlin/io/rsocket/kotlin/internal/lease/LeaseGranterConnectionTest.kt
@@ -42,7 +42,7 @@ class LeaseGranterConnectionTest {
     @Test
     fun sentLease() {
         leaseGranterConnection.send(
-                Flowable.just(Frame.Lease.from(2, 1, Unpooled.EMPTY_BUFFER)))
+                Flowable.just(Frame.Lease.from(2_000, 1, Unpooled.EMPTY_BUFFER)))
                 .blockingAwait()
         assertEquals(1.0, receive.availability(), 1e-5)
         assertEquals(0.0, send.availability(), 1e-5)

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.jfrog.artifactory'
 
 dependencies {
     api project(":rsocket-core")
-    implementation ('io.projectreactor.ipc:reactor-netty:0.7.7.RELEASE')
+    implementation ('io.projectreactor.ipc:reactor-netty:0.7.8.RELEASE')
 }
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"

--- a/rsocket-transport-netty/src/main/kotlin/io/rsocket/kotlin/transport/netty/server/TcpServerTransport.kt
+++ b/rsocket-transport-netty/src/main/kotlin/io/rsocket/kotlin/transport/netty/server/TcpServerTransport.kt
@@ -38,8 +38,7 @@ class TcpServerTransport private constructor(private var server: TcpServer)
                         inbound,
                         outbound,
                         inbound.context())
-                acceptor(connection).subscribe()
-                outbound.neverComplete()
+                acceptor(connection).andThen(outbound.neverComplete())
             }.toSingle().map { NettyContextCloseable(it) }
 
     companion object {

--- a/rsocket-transport-netty/src/main/kotlin/io/rsocket/kotlin/transport/netty/server/WebsocketRouteTransport.kt
+++ b/rsocket-transport-netty/src/main/kotlin/io/rsocket/kotlin/transport/netty/server/WebsocketRouteTransport.kt
@@ -22,11 +22,8 @@ import io.rsocket.kotlin.transport.ServerTransport
 import io.rsocket.kotlin.transport.ServerTransport.ConnectionAcceptor
 import io.rsocket.kotlin.transport.netty.WebsocketDuplexConnection
 import io.rsocket.kotlin.transport.netty.toSingle
-import reactor.core.publisher.Mono
 import reactor.ipc.netty.http.server.HttpServer
 import reactor.ipc.netty.http.server.HttpServerRoutes
-
-import java.util.function.Consumer
 
 class WebsocketRouteTransport(private val server: HttpServer,
                               private val routesBuilder: (HttpServerRoutes) -> Unit,
@@ -41,8 +38,7 @@ class WebsocketRouteTransport(private val server: HttpServer,
                                 inbound,
                                 outbound,
                                 inbound.context())
-                        acceptor(connection).subscribe()
-                        outbound.neverComplete()
+                        acceptor(connection).andThen(outbound.neverComplete())
                     }
                 }.toSingle().map { NettyContextCloseable(it) }
     }

--- a/rsocket-transport-netty/src/main/kotlin/io/rsocket/kotlin/transport/netty/server/WebsocketServerTransport.kt
+++ b/rsocket-transport-netty/src/main/kotlin/io/rsocket/kotlin/transport/netty/server/WebsocketServerTransport.kt
@@ -39,8 +39,7 @@ class WebsocketServerTransport private constructor(internal var server: HttpServ
                                         inbound,
                                         outbound,
                                         inbound.context())
-                        acceptor(connection).subscribe()
-                        outbound.neverComplete()
+                        acceptor(connection).andThen(outbound.neverComplete())
                     }
                 }.toSingle().map { NettyContextCloseable(it) }
     }

--- a/rsocket-transport-okhttp/src/main/kotlin/io/rsocket/transport/okhttp/OkWebsocket.kt
+++ b/rsocket-transport-okhttp/src/main/kotlin/io/rsocket/transport/okhttp/OkWebsocket.kt
@@ -13,9 +13,6 @@ import okio.ByteString
 import org.reactivestreams.Publisher
 import java.nio.channels.ClosedChannelException
 
-/**
- * Created by Maksym Ostroverkhov on 27.10.17.
- */
 internal class OkWebsocket(client: OkHttpClient,
                            request: Request) {
     @Volatile

--- a/rsocket-transport-okhttp/src/main/kotlin/io/rsocket/transport/okhttp/client/OkhttpWebsocketClientTransport.kt
+++ b/rsocket-transport-okhttp/src/main/kotlin/io/rsocket/transport/okhttp/client/OkhttpWebsocketClientTransport.kt
@@ -8,9 +8,6 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
-/**
- * Created by Maksym Ostroverkhov on 28.10.17.
- */
 class OkhttpWebsocketClientTransport private constructor(private val client: OkHttpClient,
                                                          private val request: Request)
     : ClientTransport {

--- a/test/src/test/kotlin/io/rsocket/kotlin/test/lease/example/LeaseClientServerExample.kt
+++ b/test/src/test/kotlin/io/rsocket/kotlin/test/lease/example/LeaseClientServerExample.kt
@@ -20,7 +20,7 @@ object LeaseClientServerExample {
 
         val serverLease = LeaseRefs()
         val nettyContextCloseable = RSocketFactory.receive()
-                .enableLease(serverLease)
+                .lease(serverLease)
                 .acceptor {
                     { _, _ ->
                         Single.just(
@@ -37,7 +37,7 @@ object LeaseClientServerExample {
 
         val address = nettyContextCloseable.address()
         val clientSocket = RSocketFactory.connect()
-                .enableLease(LeaseRefs())
+                .lease(LeaseRefs())
                 .keepAlive { opts ->
                     opts.keepAliveInterval(Duration.ofMinutes(1))
                             .keepAliveMaxLifeTime(Duration.ofMinutes(20))

--- a/test/src/test/kotlin/io/rsocket/kotlin/test/transport/NettyTcpEndToEndTest.kt
+++ b/test/src/test/kotlin/io/rsocket/kotlin/test/transport/NettyTcpEndToEndTest.kt
@@ -6,8 +6,4 @@ import io.rsocket.kotlin.transport.netty.server.TcpServerTransport
 class NettyTcpEndToEndTest
     : EndToEndTest(
         { TcpClientTransport.create(it) },
-        { TcpServerTransport.create(it) }) {
-
-    override fun response() {
-    }
-}
+        { TcpServerTransport.create(it) })

--- a/test/src/test/kotlin/io/rsocket/kotlin/test/transport/NettyWebsocketEndToEndTest.kt
+++ b/test/src/test/kotlin/io/rsocket/kotlin/test/transport/NettyWebsocketEndToEndTest.kt
@@ -1,17 +1,8 @@
 package io.rsocket.kotlin.test.transport
 
-import io.rsocket.kotlin.test.transport.EndToEndTest
 import io.rsocket.kotlin.transport.netty.client.WebsocketClientTransport
 import io.rsocket.kotlin.transport.netty.server.WebsocketServerTransport
 
 class NettyWebsocketEndToEndTest : EndToEndTest(
         { WebsocketClientTransport.create(it) },
-        { WebsocketServerTransport.create(it.port) }) {
-
-    /*noop until https://github.com/reactor/reactor-netty/pull/346 is released*/
-    override fun close() {
-    }
-
-    override fun closedAvailability() {
-    }
-}
+        { WebsocketServerTransport.create(it.port) })


### PR DESCRIPTION
* Possibility to reject setup by Server acceptor

* Client Keep-alive data support

* Client Keep-alive handler responds to Frames with `respond` flag set

* Introduce RSocketFactory ClientOptions & ServerOptions