### PR TITLE
Discuss using field updaters

### DIFF
--- a/rsocket-core/build.gradle.kts
+++ b/rsocket-core/build.gradle.kts
@@ -44,5 +44,5 @@ kotlin {
 }
 
 atomicfu {
-    variant = "BOTH"
+    variant = "FU"
 }


### PR DESCRIPTION
Combination of things

atomicfu uses FieldUpdaters on Java 8, VarHandler on Java 9+
rsocket-kotlin, kotlin 1.4 is broken on graal (JDK 8)
rsocket-kotlin, kotlin 1.4 works on graal (JDK 11) - if you avoid VarHandles

Hence raising this PR to see how much we care about this optimisation?
