### PR TITLE
Improve performance for reading of payload

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,27 @@
+name: Benchmarks
+on: workflow_dispatch
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - uses: eskatos/gradle-command-action@v1
+        name: Kotlin Benchmarks
+        with:
+          arguments: kotlinBenchmark
+
+      - uses: eskatos/gradle-command-action@v1
+        name: Java Benchmarks
+        with:
+          arguments: javaBenchmark
+
+      - uses: actions/upload-artifact@v2
+        name: Save reports
+        with:
+          name: reports
+          path: benchmarks/build/reports/benchmarks/main/*/*.json

--- a/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
+++ b/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
@@ -65,17 +65,16 @@ class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
     }
 
     override fun cleanup() {
-        println("CLEANUP")
         runBlocking {
             client.job.runCatching { cancelAndJoin() }
             server.runCatching { cancelAndJoin() }
         }
     }
 
-    override fun createPayload(size: Int): Payload = if (size == 0) Payload.Empty else Payload {
-        data(ByteArray(size / 2).also { Random.nextBytes(it) })
-        metadata(ByteArray(size / 2).also { Random.nextBytes(it) })
-    }
+    override fun createPayload(size: Int): Payload = if (size == 0) Payload.Empty else Payload(
+        ByteArray(size / 2).also { Random.nextBytes(it) },
+        ByteArray(size / 2).also { Random.nextBytes(it) }
+    )
 
     override fun releasePayload(payload: Payload) {
         payload.release()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/CancelFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/CancelFrame.kt
@@ -22,5 +22,5 @@ class CancelFrame(
     override val streamId: Int
 ) : Frame(FrameType.Cancel) {
     override val flags: Int get() = 0
-    override fun Output.writeSelf(): Unit = Unit
+    override fun BytePacketBuilder.writeSelf(): Unit = Unit
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
@@ -27,7 +27,7 @@ class ErrorFrame(
     override val flags: Int get() = 0
     val errorCode get() = (throwable as? RSocketError)?.errorCode ?: ErrorCode.ApplicationError
 
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeInt(errorCode)
         when (data) {
             null -> writeText(throwable.message ?: "")
@@ -36,7 +36,7 @@ class ErrorFrame(
     }
 }
 
-fun Input.readError(streamId: Int): ErrorFrame {
+fun ByteReadPacket.readError(streamId: Int): ErrorFrame {
     val errorCode = readInt()
     val message = readText()
     return ErrorFrame(streamId, RSocketError(streamId, errorCode, message))

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
@@ -26,13 +26,13 @@ class ExtensionFrame(
     val payload: Payload
 ) : Frame(FrameType.Extension) {
     override val flags: Int get() = if (payload.metadata != null) Flags.Metadata else 0
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeInt(extendedType)
         writePayload(payload)
     }
 }
 
-fun Input.readExtension(streamId: Int, flags: Int): ExtensionFrame {
+fun ByteReadPacket.readExtension(streamId: Int, flags: Int): ExtensionFrame {
     val extendedType = readInt()
     val payload = readPayload(flags)
     return ExtensionFrame(streamId, extendedType, payload)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
@@ -26,7 +26,7 @@ abstract class Frame(open val type: FrameType) {
     abstract val streamId: Int
     abstract val flags: Int
 
-    protected abstract fun Output.writeSelf()
+    protected abstract fun BytePacketBuilder.writeSelf()
 
     fun toPacket(): ByteReadPacket {
         check(type.canHaveMetadata || !(flags check Flags.Metadata)) { "bad value for metadata flag" }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
@@ -29,13 +29,13 @@ class KeepAliveFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = if (respond) KeepAliveFlag else 0
 
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeLong(lastPosition.coerceAtLeast(0))
         writePacket(data)
     }
 }
 
-fun Input.readKeepAlive(flags: Int): KeepAliveFrame {
+fun ByteReadPacket.readKeepAlive(flags: Int): KeepAliveFrame {
     val respond = flags check KeepAliveFlag
     val lastPosition = readLong()
     val data = readPacket()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
@@ -26,14 +26,14 @@ class LeaseFrame(
 ) : Frame(FrameType.Lease) {
     override val streamId: Int get() = 0
     override val flags: Int get() = if (metadata != null) Flags.Metadata else 0
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeInt(ttl)
         writeInt(numberOfRequests)
         writeMetadata(metadata)
     }
 }
 
-fun Input.readLease(flags: Int): LeaseFrame {
+fun ByteReadPacket.readLease(flags: Int): LeaseFrame {
     val ttl = readInt()
     val numberOfRequests = readInt()
     val metadata = if (flags check Flags.Metadata) readMetadata() else null

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
@@ -25,9 +25,9 @@ class MetadataPushFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = Flags.Metadata
 
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writePacket(metadata)
     }
 }
 
-fun Input.readMetadataPush(): MetadataPushFrame = MetadataPushFrame(readPacket())
+fun ByteReadPacket.readMetadataPush(): MetadataPushFrame = MetadataPushFrame(readPacket())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
@@ -41,13 +41,13 @@ class RequestFrame(
             return flags
         }
 
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         if (initialRequest > 0) writeInt(initialRequest)
         writePayload(payload)
     }
 }
 
-fun Input.readRequest(type: FrameType, streamId: Int, flags: Int, withInitial: Boolean): RequestFrame {
+fun ByteReadPacket.readRequest(type: FrameType, streamId: Int, flags: Int, withInitial: Boolean): RequestFrame {
     val fragmentFollows = flags check Flags.Follows
     val complete = flags check Flags.Complete
     val next = flags check Flags.Next

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
@@ -23,12 +23,12 @@ class RequestNFrame(
     val requestN: Int
 ) : Frame(FrameType.RequestN) {
     override val flags: Int get() = 0
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeInt(requestN)
     }
 }
 
-fun Input.readRequestN(streamId: Int): RequestNFrame {
+fun ByteReadPacket.readRequestN(streamId: Int): RequestNFrame {
     val requestN = readInt()
     return RequestNFrame(streamId, requestN)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
@@ -27,7 +27,7 @@ class ResumeFrame(
 ) : Frame(FrameType.Resume) {
     override val streamId: Int get() = 0
     override val flags: Int get() = 0
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeVersion(version)
         writeResumeToken(resumeToken)
         writeLong(lastReceivedServerPosition)
@@ -35,7 +35,7 @@ class ResumeFrame(
     }
 }
 
-fun Input.readResume(): ResumeFrame {
+fun ByteReadPacket.readResume(): ResumeFrame {
     val version = readVersion()
     val resumeToken = readResumeToken()
     val lastReceivedServerPosition = readLong()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
@@ -24,9 +24,9 @@ class ResumeOkFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = 0
 
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeLong(lastReceivedClientPosition)
     }
 }
 
-fun Input.readResumeOk(): ResumeOkFrame = ResumeOkFrame(readLong())
+fun ByteReadPacket.readResumeOk(): ResumeOkFrame = ResumeOkFrame(readLong())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
@@ -42,7 +42,7 @@ class SetupFrame(
             return flags
         }
 
-    override fun Output.writeSelf() {
+    override fun BytePacketBuilder.writeSelf() {
         writeVersion(version)
         writeKeepAlive(keepAlive)
         writeResumeToken(resumeToken)
@@ -51,7 +51,7 @@ class SetupFrame(
     }
 }
 
-fun Input.readSetup(flags: Int): SetupFrame {
+fun ByteReadPacket.readSetup(flags: Int): SetupFrame {
     val version = readVersion()
     val keepAlive = readKeepAlive()
     val resumeToken = if (flags check ResumeEnabledFlag) readResumeToken() else null

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/Version.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/Version.kt
@@ -32,8 +32,8 @@ inline class Version(val value: Int) {
     }
 }
 
-fun Input.readVersion(): Version = Version(readInt())
+fun ByteReadPacket.readVersion(): Version = Version(readInt())
 
-fun Output.writeVersion(version: Version) {
+fun BytePacketBuilder.writeVersion(version: Version) {
     writeInt(version.value)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/length.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/length.kt
@@ -20,14 +20,14 @@ import io.ktor.utils.io.core.*
 
 private const val lengthMask: Int = 0xFFFFFF.inv()
 
-fun Input.readLength(): Int {
+fun ByteReadPacket.readLength(): Int {
     val b = readByte().toInt() and 0xFF shl 16
     val b1 = readByte().toInt() and 0xFF shl 8
     val b2 = readByte().toInt() and 0xFF
     return b or b1 or b2
 }
 
-fun Output.writeLength(length: Int) {
+fun BytePacketBuilder.writeLength(length: Int) {
     require(length and lengthMask == 0) { "Length is larger than 24 bits" }
     writeByte((length shr 16).toByte())
     writeByte((length shr 8).toByte())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
@@ -19,25 +19,25 @@ package io.rsocket.kotlin.frame.io
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.payload.*
 
-fun Input.readMetadata(): ByteReadPacket {
+fun ByteReadPacket.readMetadata(): ByteReadPacket {
     val length = readLength()
     return readPacket(length)
 }
 
-fun Output.writeMetadata(metadata: ByteReadPacket?) {
+fun BytePacketBuilder.writeMetadata(metadata: ByteReadPacket?) {
     metadata?.let {
         writeLength(it.remaining.toInt())
         writePacket(it)
     }
 }
 
-fun Input.readPayload(flags: Int): Payload {
+fun ByteReadPacket.readPayload(flags: Int): Payload {
     val metadata = if (flags check Flags.Metadata) readMetadata() else null
     val data = readPacket()
     return Payload(data = data, metadata = metadata)
 }
 
-fun Output.writePayload(payload: Payload) {
+fun BytePacketBuilder.writePayload(payload: Payload) {
     writeMetadata(payload.metadata)
     writePacket(payload.data)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
@@ -17,17 +17,16 @@
 package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
-import io.ktor.utils.io.core.internal.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.payload.*
 import kotlin.time.*
 
-fun Input.readResumeToken(): ByteReadPacket {
+fun ByteReadPacket.readResumeToken(): ByteReadPacket {
     val length = readShort().toInt() and 0xFFFF
     return readPacket(length)
 }
 
-fun Output.writeResumeToken(resumeToken: ByteReadPacket?) {
+fun BytePacketBuilder.writeResumeToken(resumeToken: ByteReadPacket?) {
     resumeToken?.let {
         val length = it.remaining
         writeShort(length.toShort())
@@ -35,71 +34,57 @@ fun Output.writeResumeToken(resumeToken: ByteReadPacket?) {
     }
 }
 
-fun Input.readMimeType(): String {
+fun ByteReadPacket.readMimeType(): String {
     val length = readByte().toInt()
     return readText(max = length)
 }
 
-fun Output.writeMimeType(mimeType: String) {
+fun BytePacketBuilder.writeMimeType(mimeType: String) {
     val bytes = mimeType.encodeToByteArray() //TODO check
     writeByte(bytes.size.toByte())
     writeFully(bytes)
 }
 
-fun Input.readPayloadMimeType(): PayloadMimeType {
+fun ByteReadPacket.readPayloadMimeType(): PayloadMimeType {
     val metadata = readMimeType()
     val data = readMimeType()
     return PayloadMimeType(data = data, metadata = metadata)
 }
 
-fun Output.writePayloadMimeType(payloadMimeType: PayloadMimeType) {
+fun BytePacketBuilder.writePayloadMimeType(payloadMimeType: PayloadMimeType) {
     writeMimeType(payloadMimeType.metadata)
     writeMimeType(payloadMimeType.data)
 }
 
 @OptIn(ExperimentalTime::class)
-fun Input.readMillis(): Duration = readInt().milliseconds
+fun ByteReadPacket.readMillis(): Duration = readInt().milliseconds
 
 @OptIn(ExperimentalTime::class)
-fun Output.writeMillis(duration: Duration) {
+fun BytePacketBuilder.writeMillis(duration: Duration) {
     writeInt(duration.toInt(DurationUnit.MILLISECONDS))
 }
 
-fun Input.readKeepAlive(): KeepAlive {
+fun ByteReadPacket.readKeepAlive(): KeepAlive {
     val interval = readMillis()
     val maxLifetime = readMillis()
     return KeepAlive(interval = interval, maxLifetime = maxLifetime)
 }
 
-fun Output.writeKeepAlive(keepAlive: KeepAlive) {
+fun BytePacketBuilder.writeKeepAlive(keepAlive: KeepAlive) {
     writeMillis(keepAlive.interval)
     writeMillis(keepAlive.maxLifetime)
 }
 
-@OptIn(DangerousInternalIoApi::class)
-fun Input.readPacket(): ByteReadPacket {
-    if (endOfInput) return ByteReadPacket.Empty
-
-    return buildPacket { copyTo(this) }
+fun ByteReadPacket.readPacket(): ByteReadPacket {
+    if (isEmpty) return ByteReadPacket.Empty
+    return buildPacket {
+        writePacket(this@readPacket)
+    }
 }
 
-//TODO add additional test - tested in ResumeFrameTest + SetupFrameTest with big payload
-@OptIn(DangerousInternalIoApi::class)
-fun Input.readPacket(length: Int): ByteReadPacket {
+fun ByteReadPacket.readPacket(length: Int): ByteReadPacket {
     if (length == 0) return ByteReadPacket.Empty
-
     return buildPacket {
-        var remainingToRead = length
-        takeWhile { readBuffer ->
-            val readCount = minOf(remainingToRead, readBuffer.readRemaining)
-            var remainingToWrite = readCount
-            writeWhile { writeBuffer ->
-                val writeCount = minOf(remainingToWrite, writeBuffer.writeRemaining)
-                remainingToWrite -= readBuffer.readAvailable(writeBuffer, writeCount)
-                remainingToWrite > 0
-            }
-            remainingToRead -= readCount
-            remainingToRead > 0
-        }
+        writePacket(this@readPacket, length)
     }
 }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/ResumeFrameTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/ResumeFrameTest.kt
@@ -41,6 +41,21 @@ class ResumeFrameTest {
     }
 
     @Test
+    fun testBigChunkedToken() {
+        val token = ByteArray(63000) { 1 }
+        val packet = buildPacket { writeFully(token) }
+        val frame = ResumeFrame(version, packet, lastReceivedServerPosition, firstAvailableClientPosition)
+        val decodedFrame = frame.toPacket().toFrame()
+
+        assertTrue(decodedFrame is ResumeFrame)
+        assertEquals(0, decodedFrame.streamId)
+        assertEquals(version, decodedFrame.version)
+        assertBytesEquals(token, decodedFrame.resumeToken.readBytes())
+        assertEquals(lastReceivedServerPosition, decodedFrame.lastReceivedServerPosition)
+        assertEquals(firstAvailableClientPosition, decodedFrame.firstAvailableClientPosition)
+    }
+
+    @Test
     fun testSmallToken() {
         val token = ByteArray(100) { 1 }
         val frame = ResumeFrame(version, ByteReadPacket(token), lastReceivedServerPosition, firstAvailableClientPosition)


### PR DESCRIPTION
* Use `writePacket` function to use zero copy reading of packets instead of hand written.
Significantly improved performance when working with big payloads.
* Benchmarks updated for comparing different request strategies