### PR TITLE
Update coroutines

### DIFF
--- a/examples/nodejs-tcp-transport/src/jsMain/kotlin/Server.kt
+++ b/examples/nodejs-tcp-transport/src/jsMain/kotlin/Server.kt
@@ -57,7 +57,7 @@ fun NodeJsTcpServerTransport(port: Int, onStart: () -> Unit = {}): ServerTranspo
 // nodejs TCP transport connection - may not work in all cases, not tested properly
 @OptIn(ExperimentalCoroutinesApi::class, TransportApi::class)
 class NodeJsTcpConnection(private val socket: Socket) : Connection {
-    override val job: Job = Job()
+    override val job: CompletableJob = Job()
 
     private val sendChannel = Channel<ByteReadPacket>(8)
     private val receiveChannel = Channel<ByteReadPacket>(8)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,9 @@ group=io.rsocket.kotlin
 version=0.12.0
 
 #Versions
-kotlinVersion=1.4.20
+kotlinVersion=1.4.21
 ktorVersion=1.4.3
-kotlinxCoroutinesVersion=1.3.9-native-mt-2
+kotlinxCoroutinesVersion=1.4.2-native-mt
 kotlinxAtomicfuVersion=0.14.4
 kotlinxSerializationVersion=1.0.1
 kotlinxBenchmarkVersion=0.2.0-dev-20

--- a/playground/src/commonMain/kotlin/streams.kt
+++ b/playground/src/commonMain/kotlin/streams.kt
@@ -18,12 +18,11 @@ import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
-import kotlin.coroutines.*
 
 @ExperimentalStreamsApi
 private suspend fun s() {
     val flow = flow {
-        val strategy = coroutineContext[RequestStrategy]!!.provide()
+        val strategy = currentCoroutineContext()[RequestStrategy]!!.provide()
         var i = strategy.firstRequest()
         println("INIT: $i")
         var r = 0

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Cancellable.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Cancellable.kt
@@ -18,12 +18,10 @@ package io.rsocket.kotlin
 
 import kotlinx.coroutines.*
 
-interface Cancelable {
-    val job: Job
+interface Cancellable {
+    val job: CompletableJob
 }
 
-val Cancelable.isActive: Boolean get() = job.isActive
-fun Cancelable.cancel(cause: CancellationException? = null): Unit = job.cancel(cause)
-fun Cancelable.cancel(message: String, cause: Throwable? = null): Unit = job.cancel(message, cause)
-suspend fun Cancelable.join(): Unit = job.join()
-suspend fun Cancelable.cancelAndJoin(): Unit = job.cancelAndJoin()
+val Cancellable.isActive: Boolean get() = job.isActive
+suspend fun Cancellable.join(): Unit = job.join()
+suspend fun Cancellable.cancelAndJoin(): Unit = job.cancelAndJoin()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
@@ -25,7 +25,7 @@ import io.rsocket.kotlin.frame.*
  * That interface isn't stable for inheritance.
  */
 @TransportApi
-interface Connection : Cancelable {
+interface Connection : Cancellable {
 
     @DangerousInternalIoApi
     val pool: ObjectPool<ChunkBuffer>

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.flow.*
 
-interface RSocket : Cancelable {
+interface RSocket : Cancellable {
 
     suspend fun metadataPush(metadata: ByteReadPacket) {
         metadata.release()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketRequestHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketRequestHandler.kt
@@ -53,7 +53,7 @@ class RSocketRequestHandlerBuilder internal constructor() {
         requestChannel = block
     }
 
-    internal fun build(job: Job): RSocket =
+    internal fun build(job: CompletableJob): RSocket =
         RSocketRequestHandler(job, metadataPush, fireAndForget, requestResponse, requestStream, requestChannel)
 }
 
@@ -65,7 +65,7 @@ fun RSocketRequestHandler(parentJob: Job? = null, configure: RSocketRequestHandl
 }
 
 private class RSocketRequestHandler(
-    override val job: Job,
+    override val job: CompletableJob,
     private val metadataPush: (suspend RSocket.(metadata: ByteReadPacket) -> Unit)? = null,
     private val fireAndForget: (suspend RSocket.(payload: Payload) -> Unit)? = null,
     private val requestResponse: (suspend RSocket.(payload: Payload) -> Payload)? = null,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -100,10 +100,10 @@ public class RSocketConnectorBuilder internal constructor() {
     )
 
     private companion object {
-        private val defaultAcceptor: ConnectionAcceptor = ConnectionAcceptor { EmptyRSocket }
+        private val defaultAcceptor: ConnectionAcceptor = ConnectionAcceptor { EmptyRSocket() }
 
-        private object EmptyRSocket : RSocket {
-            override val job: Job = NonCancellable
+        private class EmptyRSocket : RSocket {
+            override val job: CompletableJob = Job()
         }
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -68,7 +68,7 @@ class RSocketServer internal constructor(
 
     private suspend fun Connection.failSetup(error: RSocketError.Setup): Nothing {
         sendFrame(ErrorFrame(0, error))
-        cancel("Setup failed", error)
+        job.completeExceptionally(error)
         throw error
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.*
 internal class RSocketRequester(
     private val state: RSocketState,
     private val streamId: StreamId,
-) : RSocket, Cancelable by state {
+) : RSocket, Cancellable by state {
 
     override suspend fun metadataPush(metadata: ByteReadPacket): Unit = metadata.closeOnError {
         checkAvailable()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketResponder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketResponder.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.*
 internal class RSocketResponder(
     private val state: RSocketState,
     private val requestHandler: RSocket,
-) : Cancelable by state {
+) : Cancellable by state {
 
     fun handleMetadataPush(frame: MetadataPushFrame) {
         state.launch {

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/SetupRejectionTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/SetupRejectionTest.kt
@@ -56,6 +56,9 @@ class SetupRejectionTest : SuspendTest, TestWithLeakCheck {
             }
             val sender = sendingRSocket.await()
             assertFalse(sender.isActive)
+            val error = expectError()
+            assertTrue(error is RSocketError.Setup.Rejected)
+            assertEquals(errorMessage, error.message)
         }
     }
 

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
@@ -87,7 +87,7 @@ class KeepAliveTest : TestWithConnection(), TestWithLeakCheck {
 
     @Test
     fun noKeepAliveSentAfterRSocketCanceled() = test {
-        requester().cancel()
+        requester().job.cancel()
         connection.test {
             expectNoEventsIn(500)
         }

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestConnection.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestConnection.kt
@@ -30,7 +30,7 @@ import kotlin.time.*
 
 class TestConnection : Connection, CoroutineScope {
     override val pool: ObjectPool<ChunkBuffer> = InUseTrackingPool
-    override val job: Job = Job()
+    override val job: CompletableJob = Job()
     override val coroutineContext: CoroutineContext = job + Dispatchers.Unconfined
 
     private val sendChannel = Channel<ByteReadPacket>(Channel.UNLIMITED)

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 
 class TestRSocket : RSocket {
-    override val job: Job = Job()
+    override val job: CompletableJob = Job()
 
     override suspend fun metadataPush(metadata: ByteReadPacket): Unit = metadata.release()
 

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
@@ -25,16 +25,18 @@ import io.ktor.utils.io.core.internal.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.io.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.*
 import kotlin.coroutines.*
+import kotlin.native.concurrent.*
 
 @OptIn(KtorExperimentalAPI::class, TransportApi::class, DangerousInternalIoApi::class)
 internal class TcpConnection(private val socket: Socket) : Connection, CoroutineScope {
-    override val job: Job = Job(socket.socketContext)
+    override val job: CompletableJob = Job(socket.socketContext)
     override val coroutineContext: CoroutineContext = job + Dispatchers.Unconfined
 
-    private val sendChannel = Channel<ByteReadPacket>(8)
-    private val receiveChannel = Channel<ByteReadPacket>(8)
+    private val sendChannel = SafeChannel<ByteReadPacket>(8)
+    private val receiveChannel = SafeChannel<ByteReadPacket>(8)
 
     init {
         launch {
@@ -58,9 +60,20 @@ internal class TcpConnection(private val socket: Socket) : Connection, Coroutine
                 }
             }
         }
+        job.invokeOnCompletion { cause ->
+            val error = cause?.let { it as? CancellationException ?: CancellationException("Connection failed", it) }
+            sendChannel.cancel(error)
+            receiveChannel.cancel(error)
+        }
     }
 
     override suspend fun send(packet: ByteReadPacket): Unit = sendChannel.send(packet)
 
     override suspend fun receive(): ByteReadPacket = receiveChannel.receive()
 }
+
+@SharedImmutable
+private val onUndeliveredCloseable: (Closeable) -> Unit = Closeable::close
+
+@Suppress("FunctionName")
+private fun <E : Closeable> SafeChannel(capacity: Int): Channel<E> = Channel(capacity, onUndeliveredElement = onUndeliveredCloseable)

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.*
 @TransportApi
 public class WebSocketConnection(private val session: WebSocketSession) : Connection {
 
-    override val job: Job get() = session.coroutineContext[Job]!!
+    override val job: CompletableJob = Job(session.coroutineContext[Job])
 
     override suspend fun send(packet: ByteReadPacket) {
         session.send(Frame.Binary(true, packet))

--- a/rsocket-transport-ktor/src/nativeTest/kotlin/io/rsocket/kotlin/NativeTcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/nativeTest/kotlin/io/rsocket/kotlin/NativeTcpTransportTest.kt
@@ -42,7 +42,7 @@ class NativeTcpTransportTest : TransportTest() {
 
     override suspend fun after() {
         serverJob.cancel()
-        client.cancel()
+        client.job.cancel()
         server.close()
         serverJob.join()
         client.join()


### PR DESCRIPTION
* minor: kotlin 1.4.21
* coroutines 1.4.2-native-mt
* Use `Flow.stateIn` operator from coroutines 1.4.x in reconnectable implementation
* minor: Rename `Cancelable` to `Cancellable` (double L)
* use `CompletableJob` in `Cancellable` interface for better connection state handling
* use `CompletableJob.completeExceptionally` instead of `Job.cancel` in places, where error should happen
* use new channel API with `onUndeliveredElement` (yet workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2435 left)
* introduce `SendChannel.safeOffer` for better releasing of frames/payloads if channel is closed
* better channel handing in TCP and local transports

Overall: less leaks and better structured concurrency