### PR TITLE
add workaround for KT-44884

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -231,6 +231,19 @@ subprojects {
             }
         }
     }
+
+    //workaround for https://youtrack.jetbrains.com/issue/KT-44884
+    configurations.matching { it.name != "kotlinCompilerPluginClasspath" }.all {
+        resolutionStrategy.eachDependency {
+            val version = requested.version
+            if (requested.group == "org.jetbrains.kotlinx" &&
+                requested.name.startsWith("kotlinx-coroutines") &&
+                version != null && !version.contains("native-mt")
+            ) {
+                useVersion("$version-native-mt")
+            }
+        }
+    }
 }
 
 

--- a/rsocket-test/build.gradle.kts
+++ b/rsocket-test/build.gradle.kts
@@ -33,10 +33,7 @@ kotlin {
 
                 api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
                 api("io.ktor:ktor-utils:$ktorVersion")
-                api("app.cash.turbine:turbine:$turbineVersion") {
-                    //depends on coroutines without native-mt suffix, so need to exclude it
-                    exclude("org.jetbrains.kotlinx")
-                }
+                api("app.cash.turbine:turbine:$turbineVersion")
             }
         }
         val jvmMain by getting {


### PR DESCRIPTION
Workaround for not working caching of native debug code. (issue https://youtrack.jetbrains.com/issue/KT-44884)

### Motivation:

K/N macos and ios targets support caching in debug builds, but caching not working when using `exclude` for now. Cached builds are much faster.
