### PR TITLE
ktor 1.5.3 + reworked leak tracking

### DIFF
--- a/examples/multiplatform-chat/build.gradle.kts
+++ b/examples/multiplatform-chat/build.gradle.kts
@@ -28,7 +28,7 @@ val kotlinxSerializationVersion: String by rootProject
 kotlin {
     jvm("serverJvm")
     jvm("clientJvm")
-    js("clientJs") {
+    js("clientJs", IR) {
         browser {
             binaries.executable()
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ group=io.rsocket.kotlin
 version=0.13.0
 
 #Versions
-kotlinVersion=1.4.31
-ktorVersion=1.5.2
+kotlinVersion=1.4.32
+ktorVersion=1.5.3
 kotlinxCoroutinesVersion=1.4.3-native-mt
 kotlinxAtomicfuVersion=0.15.2
 kotlinxSerializationVersion=1.1.0
@@ -46,7 +46,7 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 #JS and Native flags
-kotlin.js.compiler=ir
+kotlin.js.compiler=both
 kotlin.native.enableDependencyPropagation=false
 kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.ignoreDisabledTargets=true

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -24,7 +24,7 @@ val ktorVersion: String by rootProject
 
 kotlin {
     jvm()
-    js {
+    js(IR) {
         browser {
             binaries.executable()
         }

--- a/publish-check/build.gradle.kts
+++ b/publish-check/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     //all targets depends on core and local transport
 
     jvm() //depends on ktor client and server
-    js { //depends on ktor client
+    js(IR) { //depends on ktor client
         browser()
         nodejs()
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
@@ -20,6 +20,7 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.internal.*
 
 /**
  * That interface isn't stable for inheritance.
@@ -39,4 +40,7 @@ interface Connection : Cancellable {
 internal suspend fun Connection.receiveFrame(): Frame = receive().readFrame(pool)
 
 @OptIn(DangerousInternalIoApi::class, TransportApi::class)
-internal suspend fun Connection.sendFrame(frame: Frame): Unit = send(frame.toPacket(pool))
+internal suspend fun Connection.sendFrame(frame: Frame) {
+    val packet = frame.toPacket(pool)
+    packet.closeOnError { send(packet) }
+}

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
@@ -49,3 +49,16 @@ interface RSocket : Cancellable {
 }
 
 private fun notImplemented(operation: String): Nothing = throw NotImplementedError("$operation is not implemented.")
+
+/**
+ * Tries to emit [value], if emit failed, f.e. due cancellation, calls [Closeable.close] on [value].
+ * Better to use it instead of [FlowCollector.emit] with [Payload] or [ByteReadPacket] to avoid leaks of dropped elements.
+ */
+public suspend fun <C : Closeable> FlowCollector<C>.emitOrClose(value: C) {
+    try {
+        return emit(value)
+    } catch (e: Throwable) {
+        value.close()
+        throw e
+    }
+}

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketState.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketState.kt
@@ -82,7 +82,7 @@ internal class RSocketState(
         //TODO fragmentation
         for (frame in receiver) {
             if (frame.complete) return //TODO check next flag
-            collector.emit(frame.payload)
+            collector.emitOrClose(frame.payload)
             val next = strategy.nextRequest()
             if (next > 0) send(RequestNFrame(streamId, next))
         }
@@ -187,7 +187,7 @@ internal class RSocketState(
         scope.launch {
             while (connection.isActive) {
                 val frame = prioritizer.receive()
-                frame.closeOnError { connection.sendFrame(frame) }
+                connection.sendFrame(frame)
             }
         }
         scope.launch {

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/RSocketTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/RSocketTest.kt
@@ -48,12 +48,12 @@ class RSocketTest : SuspendTest, TestWithLeakCheck {
                 requestResponse { it }
                 requestStream {
                     it.release()
-                    flow { repeat(10) { emit(payload("server got -> [$it]")) } }
+                    flow { repeat(10) { emitOrClose(payload("server got -> [$it]")) } }
                 }
                 requestChannel { init, payloads ->
                     init.release()
                     payloads.onEach { it.release() }.launchIn(CoroutineScope(job))
-                    flow { repeat(10) { emit(payload("server got -> [$it]")) } }
+                    flow { repeat(10) { emitOrClose(payload("server got -> [$it]")) } }
                 }
             }
         }

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/InUseTrackingPool.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/InUseTrackingPool.kt
@@ -16,39 +16,105 @@
 
 package io.rsocket.kotlin.test
 
+import io.ktor.utils.io.bits.*
+import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
-import kotlinx.atomicfu.*
 import kotlin.test.*
 
+@Suppress("DEPRECATION", "INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "UNCHECKED_CAST")
 object InUseTrackingPool : ObjectPool<ChunkBuffer> {
-    override val capacity: Int get() = ChunkBuffer.Pool.capacity
-    private val inUse = atomic(0)
+    override val capacity: Int get() = BufferPool.capacity
+    private val inUse = TrackingSet()
 
     override fun borrow(): ChunkBuffer {
-        inUse.incrementAndGet()
-        return ChunkBuffer.Pool.borrow()
+        val instance = BufferPool.borrow()
+        inUse.add(instance)
+        return instance
     }
 
     override fun recycle(instance: ChunkBuffer) {
-        inUse.decrementAndGet()
-        ChunkBuffer.Pool.recycle(instance)
+        inUse.remove(instance)
+        BufferPool.recycle(instance as IoBuffer)
     }
 
     override fun dispose() {
-        ChunkBuffer.Pool.dispose()
+        BufferPool.dispose()
     }
 
     fun resetInUse() {
-        inUse.lazySet(0)
+        inUse.clear()
     }
 
     fun assertNoInUse() {
-        val v = inUse.value
-        assertEquals(0, v, "Buffers in use")
+        val traces = inUse.traces() ?: return
+        fail(traceMessage(traces))
+    }
+
+    private fun traceMessage(traces: List<Throwable>): String = traces
+        .groupBy(Throwable::stackTraceToString)
+        .mapKeys { alignStackTrace(it.key) }
+        .mapValues { it.value.size }
+        .toList()
+        .joinToString("\n", "Buffers in use[${traces.size}]:\n", "\n") { (stack, amount) ->
+            "Buffer creation trace ($amount the same):\n$stack"
+        }
+
+    private fun alignStackTrace(trace: String): String {
+        val stack = trace.split("\n").drop(1) // drops first empty trace
+        val filtered =
+            stack
+                .filterNot { it.contains("TrackingSet") || it.contains("InUseTrackingPool") } //filter not relevant
+                .filter {
+                    //works on K/JVM and K/N
+                    //on K/JS works only for legacy + node
+                    it.contains("io.rsocket.kotlin") || it.contains("rsocket-kotlin/rsocket")
+                }.ifEmpty { stack } //fallback to full stacktrace on unsupported K/JS variants
+
+        //replaces `at` with `->` because on all platforms except K/JVM such strings are interpreted as stacktrace and merged
+        return filtered.joinToString("\n  ->", "  ->") { it.substringAfter("at") }
+    }
+
+    //uses internal ktor APIs -
+    // after ktor 1.5.3 it's the only way to make sure,
+    // that there are no leaked buffers
+    // used only on tests, so it's more or less safe
+    // copy of io.ktor.utils.io.core.DefaultBufferPool with changed parent pool!!!
+    private object BufferPool : DefaultPool<IoBuffer>(1000) {
+        override fun produceInstance(): IoBuffer {
+            return IoBuffer(DefaultAllocator.alloc(DEFAULT_BUFFER_SIZE), null, InUseTrackingPool as ObjectPool<IoBuffer>)
+        }
+
+        override fun disposeInstance(instance: IoBuffer) {
+            DefaultAllocator.free(instance.memory)
+            super.disposeInstance(instance)
+            instance.unlink()
+        }
+
+        override fun validateInstance(instance: IoBuffer) {
+            super.validateInstance(instance)
+
+            check(instance !== IoBuffer.Empty) { "Empty instance couldn't be recycled" }
+            check(instance !== Buffer.Empty) { "Empty instance couldn't be recycled" }
+            check(instance !== ChunkBuffer.Empty) { "Empty instance couldn't be recycled" }
+
+            check(instance.referenceCount == 0) { "Unable to clear buffer: it is still in use." }
+            check(instance.next == null) { "Recycled instance shouldn't be a part of a chain." }
+            check(instance.origin == null) { "Recycled instance shouldn't be a view or another buffer." }
+        }
+
+        override fun clearInstance(instance: IoBuffer): IoBuffer {
+            return super.clearInstance(instance).apply {
+                unpark()
+                reset()
+            }
+        }
     }
 }
 
+//TODO leak tracking don't work on JS in SuspendTest
+// due to `hack`, that to run `suspend` tests on JS, we return `Promise`, for which kotlin JS test runner will subscribe
+// in such cases `AfterTest` will be called just after `Promise` returned, and not when it resolved
 interface TestWithLeakCheck {
 
     @BeforeTest

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
@@ -35,12 +35,15 @@ class TestRSocket : RSocket {
     }
 
     override fun requestStream(payload: Payload): Flow<Payload> = flow {
-        repeat(10000) { emit(requestResponse(payload)) }
+        payload.release()
+        repeat(10000) {
+            emitOrClose(Payload(packet(data), packet(metadata)))
+        }
     }
 
     override fun requestChannel(initPayload: Payload, payloads: Flow<Payload>): Flow<Payload> = flow {
         initPayload.release()
-        payloads.collect { emit(it) }
+        payloads.collect { emitOrClose(it) }
     }
 
     companion object {

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TrackingSet.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TrackingSet.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.test
+
+import io.ktor.utils.io.core.internal.*
+import kotlinx.atomicfu.locks.*
+
+class TrackingSet : SynchronizedObject() {
+    private val set = MSet<IdentityWrapper>()
+    private inline fun <T> sync(block: MSet<IdentityWrapper>.() -> T): T = synchronized(this) { block(set) }
+
+    fun add(element: ChunkBuffer) = sync { check(add(IdentityWrapper(element, Throwable()))) }
+    fun remove(element: ChunkBuffer) = sync { check(remove(IdentityWrapper(element, null))) }
+    fun clear() = sync { clear() }
+    fun traces(): List<Throwable>? {
+        val list = sync { values() }
+        if (list.isEmpty()) return null
+        return list.mapNotNull(IdentityWrapper::throwable)
+    }
+}
+
+private class IdentityWrapper(
+    private val instance: ChunkBuffer,
+    val throwable: Throwable?
+) {
+    override fun equals(other: Any?): Boolean {
+        if (other !is IdentityWrapper) return false
+        return other.instance === this.instance
+    }
+
+    override fun hashCode(): Int = identityHashCode(instance)
+}
+
+expect fun identityHashCode(instance: Any): Int
+
+expect class MSet<T>() {
+    fun add(element: T): Boolean
+    fun remove(element: T): Boolean
+    fun clear()
+    fun values(): List<T>
+}

--- a/rsocket-test/src/jsMain/kotlin/io/rsocket/kotlin/test/MSet.kt
+++ b/rsocket-test/src/jsMain/kotlin/io/rsocket/kotlin/test/MSet.kt
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("multiplatform")
-}
+package io.rsocket.kotlin.test
 
-val kotlinxNodejsVersion: String by rootProject
+actual fun identityHashCode(instance: Any): Int = instance.hashCode()
 
-kotlin {
-    js(IR) {
-        nodejs {
-            binaries.executable()
-        }
-    }
-
-    sourceSets {
-        val jsMain by getting {
-            dependencies {
-                implementation(project(":rsocket-core"))
-                implementation("org.jetbrains.kotlinx:kotlinx-nodejs:$kotlinxNodejsVersion")
-            }
-        }
-    }
+actual class MSet<T> actual constructor() {
+    private val delegate = mutableSetOf<T>()
+    actual fun add(element: T): Boolean = delegate.add(element)
+    actual fun remove(element: T): Boolean = delegate.remove(element)
+    actual fun clear(): Unit = delegate.clear()
+    actual fun values(): List<T> = delegate.toList()
 }

--- a/rsocket-test/src/jvmMain/kotlin/io/rsocket/kotlin/test/MSet.kt
+++ b/rsocket-test/src/jvmMain/kotlin/io/rsocket/kotlin/test/MSet.kt
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("multiplatform")
-}
+package io.rsocket.kotlin.test
 
-val kotlinxNodejsVersion: String by rootProject
+actual fun identityHashCode(instance: Any): Int = System.identityHashCode(instance)
 
-kotlin {
-    js(IR) {
-        nodejs {
-            binaries.executable()
-        }
-    }
-
-    sourceSets {
-        val jsMain by getting {
-            dependencies {
-                implementation(project(":rsocket-core"))
-                implementation("org.jetbrains.kotlinx:kotlinx-nodejs:$kotlinxNodejsVersion")
-            }
-        }
-    }
+actual class MSet<T> actual constructor() {
+    private val delegate = mutableSetOf<T>()
+    actual fun add(element: T): Boolean = delegate.add(element)
+    actual fun remove(element: T): Boolean = delegate.remove(element)
+    actual fun clear(): Unit = delegate.clear()
+    actual fun values(): List<T> = delegate.toList()
 }

--- a/rsocket-test/src/nativeMain/kotlin/io/rsocket/kotlin/test/MSet.kt
+++ b/rsocket-test/src/nativeMain/kotlin/io/rsocket/kotlin/test/MSet.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.test
+
+import kotlinx.atomicfu.*
+import kotlin.math.*
+import kotlin.native.*
+
+actual fun identityHashCode(instance: Any): Int = instance.identityHashCode()
+
+//implementation is based on SharedSet/SharedVector from ktor-io tests
+//supports freezing
+actual class MSet<T> {
+    private var _size: Int by atomic(0)
+    private var content by atomic(MVector<MVector<T>>())
+    private val loadFactor: Float get() = _size.toFloat() / content.size
+
+    init {
+        initBuckets(8)
+    }
+
+    actual fun add(element: T): Boolean {
+        val bucket = findBucket(element)
+
+        if (bucket.find(element) >= 0) {
+            return false
+        }
+
+        bucket.push(element)
+        _size++
+
+        if (loadFactor > 0.75) {
+            doubleSize()
+        }
+
+        return true
+    }
+
+    actual fun remove(element: T): Boolean {
+        val bucket = findBucket(element)
+        val result = bucket.remove(element)
+
+        if (result) {
+            _size--
+        }
+
+        return result
+    }
+
+    private fun doubleSize() {
+        val old = content
+        initBuckets(content.size * 2)
+        _size = 0
+
+        for (bucketId in 0 until old.size) {
+            val bucket = old[bucketId]
+            for (itemId in 0 until bucket.size) {
+                add(bucket[itemId])
+            }
+        }
+    }
+
+    private fun initBuckets(count: Int) {
+        val newContent = MVector<MVector<T>>()
+        repeat(count) {
+            newContent.push(MVector())
+        }
+
+        content = newContent
+    }
+
+    private fun findBucket(element: T): MVector<T> = content[(element.hashCode().absoluteValue) % content.size]
+
+    actual fun clear() {
+        content.values().forEach(MVector<T>::clear)
+        content.clear()
+        initBuckets(8)
+        _size = 0
+    }
+
+    actual fun values(): List<T> = content.values().flatMap(MVector<T>::values)
+}
+
+
+private class MVector<T> {
+    private var _size by atomic(0)
+    private var content: AtomicArray<T?> by atomic(atomicArrayOfNulls<T>(10))
+
+    val size: Int get() = _size
+
+    fun values(): List<T> = buildList {
+        repeat(content.size) {
+            content[it].value?.let(::add)
+        }
+    }
+
+    fun push(element: T) {
+        if (_size >= content.size) {
+            increaseCapacity()
+        }
+
+        content[_size].value = element
+        _size++
+    }
+
+    fun find(element: T): Int {
+        for (index in 0 until _size) {
+            if (element == content[index].value) {
+                return index
+            }
+        }
+
+        return -1
+    }
+
+    operator fun get(index: Int): T {
+        if (index >= _size) {
+            throw IndexOutOfBoundsException("Index: $index, size: $size.")
+        }
+
+        return content[index].value!!
+    }
+
+    fun remove(element: T): Boolean {
+        val index = find(element)
+        if (index < 0) {
+            return false
+        }
+
+        if (index >= size) {
+            throw IndexOutOfBoundsException("Index: $index, size: $size.")
+        }
+
+        for (current in index until _size - 1) {
+            content[current].value = content[current + 1].value
+        }
+
+        content[_size - 1].value = null
+        _size--
+        return true
+    }
+
+    fun clear() {
+        _size = 0
+        content = atomicArrayOfNulls(0)
+    }
+
+    private fun increaseCapacity() {
+        val newContent = atomicArrayOfNulls<T>(content.size * 2)
+        for (index in 0 until content.size) {
+            newContent[index].value = content[index].value
+        }
+
+        content = newContent
+    }
+}

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
@@ -57,7 +57,12 @@ internal class TcpConnection(private val socket: Socket) : Connection, Coroutine
                 while (isActive) {
                     val length = readPacket(3).readLength()
                     val packet = readPacket(length)
-                    receiveChannel.send(packet)
+                    try {
+                        receiveChannel.send(packet)
+                    } catch (cause: Throwable) {
+                        packet.close()
+                        throw cause
+                    }
                 }
             }
         }

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
@@ -32,11 +32,7 @@ public class WebSocketConnection(private val session: WebSocketSession) : Connec
 
     override suspend fun receive(): ByteReadPacket {
         val frame = session.incoming.receive()
-        // TODO replace with ByteReadPacket(frame.data) after fix for KTOR-960
-        //  now it's not zero copy
-        return buildPacket {
-            writeFully(frame.data)
-        }
+        return ByteReadPacket(frame.data)
     }
 
 }

--- a/rsocket-transport-ktor/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTransport.kt
+++ b/rsocket-transport-ktor/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTransport.kt
@@ -41,12 +41,12 @@ public class TcpServer(public val socket: ServerSocket) : ServerTransport<Job>, 
     override val coroutineContext: CoroutineContext = socket.socketContext + Dispatchers.Unconfined
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun start(accept: suspend (Connection) -> Unit): Job = launch {
+    override fun start(accept: suspend (Connection) -> Unit): Job = launch(start = CoroutineStart.UNDISPATCHED) {
         supervisorScope {
             while (isActive) {
                 val clientSocket = socket.accept()
                 val connection = TcpConnection(clientSocket)
-                launch { accept(connection) }
+                launch(start = CoroutineStart.UNDISPATCHED) { accept(connection) }
             }
         }
     }

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/WebSocketConnectionTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/WebSocketConnectionTest.kt
@@ -38,7 +38,7 @@ import io.ktor.websocket.WebSockets as ServerWebSockets
 import io.rsocket.kotlin.transport.ktor.client.RSocketSupport as ClientRSocketSupport
 import io.rsocket.kotlin.transport.ktor.server.RSocketSupport as ServerRSocketSupport
 
-class WebSocketConnectionTest : SuspendTest {
+class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
     private val port = Random.nextInt(20, 90) * 100
     private val client = HttpClient(ClientCIO) {
         install(ClientWebSockets)
@@ -64,7 +64,7 @@ class WebSocketConnectionTest : SuspendTest {
                         flow {
                             var i = 0
                             while (true) {
-                                emit(buildPayload { data((++i).toString()) })
+                                emitOrClose(buildPayload { data((++i).toString()) })
                                 delay(1000)
                             }
                         }

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/WebSocketTransportTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/WebSocketTransportTest.kt
@@ -60,7 +60,9 @@ abstract class WebSocketTransportTest(
     override suspend fun after() {
         super.after()
 
-        server.stop(0, 0)
+        server.stop(0, 1000)
+        httpClient.close()
+        httpClient.coroutineContext.job.join()
     }
 
     private suspend inline fun <R> trySeveralTimes(block: () -> R): R {

--- a/rsocket-transport-local/src/commonTest/kotlin/io/rsocket/kotlin/transport/local/LocalTransportTest.kt
+++ b/rsocket-transport-local/src/commonTest/kotlin/io/rsocket/kotlin/transport/local/LocalTransportTest.kt
@@ -19,7 +19,7 @@ package io.rsocket.kotlin.transport.local
 import io.rsocket.kotlin.test.*
 import kotlinx.coroutines.*
 
-class LocalTransportTest : TransportTest(), TestWithLeakCheck {
+class LocalTransportTest : TransportTest() {
 
     private val testJob: Job = Job()
 


### PR DESCRIPTION
Update ktor version and rework leak tracking mechanism
also keep track for future [KTOR-2442](https://youtrack.jetbrains.com/issue/KTOR-2442)

### Motivation:

In ktor 1.5.3 after fix for [KTOR-960](https://youtrack.jetbrains.com/issue/KTOR-960) which under the hood reworks how `ktor-io` works with pools. 
To keep using leak tracking in tests, custom pool need rework.

### Modifications:

* ktor 1.5.3 + remove workaround for KTOR-960
* kotlin 1.4.32
* rework leak tracking because of changes in ktor 1.5.3 
  * for now uses some `internal` ktor APIs, but only in tests (TODO after [KTOR-2442](https://youtrack.jetbrains.com/issue/KTOR-2442))
  * print traces of leaked buffers
  * add leak check for all transport tests (previously only `Local` was tested)
* add public `FlowCollector.emitOrClose` WA for absence of operator like `onElementDrop` (https://github.com/Kotlin/kotlinx.coroutines/issues/2642)
* turn JS both mode back for better stacktraces (IR doesn't support source maps yet [KT-39447](https://youtrack.jetbrains.com/issue/KT-39447))

### Result:

* Several leaks were found and fixed
* Found, that leak tracker don't work for JS + suspend tests because `AfterTest` called too early - will be fixed in coming PR