### PR TITLE
Improve TCP transport

### DIFF
--- a/examples/multiplatform-chat/src/clientMain/kotlin/Api.kt
+++ b/examples/multiplatform-chat/src/clientMain/kotlin/Api.kt
@@ -45,7 +45,7 @@ suspend fun connectToApiUsingWS(name: String): Api {
 
 @OptIn(InternalAPI::class)
 suspend fun connectToApiUsingTCP(name: String): Api {
-    val transport = aSocket(SelectorManager()).tcp().clientTransport("0.0.0.0", 8000)
+    val transport = TcpClientTransport(SelectorManager(), "0.0.0.0", 8000)
     return Api(connector(name).connect(transport))
 }
 

--- a/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
+++ b/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.*
 
-@OptIn(KtorExperimentalAPI::class, ExperimentalSerializationApi::class, ExperimentalMetadataApi::class)
+@OptIn(KtorExperimentalAPI::class, ExperimentalSerializationApi::class, ExperimentalMetadataApi::class, InternalAPI::class)
 fun main() {
     val proto = ConfiguredProtoBuf
     val users = Users()
@@ -98,8 +98,7 @@ fun main() {
     }
 
     //start TCP server
-    val tcpTransport = aSocket(ActorSelectorManager(Dispatchers.IO)).tcp().serverTransport(port = 8000)
-    rSocketServer.bind(tcpTransport, acceptor)
+    rSocketServer.bind(TcpServerTransport(ActorSelectorManager(Dispatchers.IO), port = 9000), acceptor)
 
     //start WS server
     embeddedServer(CIO, port = 9000) {

--- a/playground/src/commonMain/kotlin/TCP.kt
+++ b/playground/src/commonMain/kotlin/TCP.kt
@@ -25,14 +25,14 @@ import kotlin.coroutines.*
 
 @OptIn(KtorExperimentalAPI::class, InternalAPI::class)
 suspend fun runTcpClient(dispatcher: CoroutineContext) {
-    val transport = aSocket(SelectorManager(dispatcher)).tcp().clientTransport("0.0.0.0", 4444)
+    val transport = TcpClientTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
     RSocketConnector().connect(transport).doSomething()
 }
 
 //to test nodejs tcp server
 @OptIn(KtorExperimentalAPI::class, InternalAPI::class)
 suspend fun testNodeJsServer(dispatcher: CoroutineContext) {
-    val transport = aSocket(SelectorManager(dispatcher)).tcp().clientTransport("127.0.0.1", 9000)
+    val transport = TcpClientTransport(SelectorManager(dispatcher), "127.0.0.1", 9000)
     val client = RSocketConnector().connect(transport)
 
     val response = client.requestResponse(buildPayload { data("Hello from JVM") })

--- a/playground/src/jvmMain/kotlin/TcpServerApp.kt
+++ b/playground/src/jvmMain/kotlin/TcpServerApp.kt
@@ -15,7 +15,6 @@
  */
 
 import io.ktor.network.selector.*
-import io.ktor.network.sockets.*
 import io.ktor.util.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.transport.ktor.*
@@ -24,7 +23,7 @@ import kotlin.coroutines.*
 
 @OptIn(KtorExperimentalAPI::class, InternalAPI::class)
 suspend fun runTcpServer(dispatcher: CoroutineContext) {
-    val transport = aSocket(SelectorManager(dispatcher)).tcp().serverTransport("0.0.0.0", 4444)
+    val transport = TcpServerTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
     RSocketServer().bind(transport, rSocketAcceptor).join()
 }
 

--- a/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/Builders.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/Builders.kt
@@ -25,18 +25,18 @@ import io.rsocket.kotlin.transport.*
 
 public suspend fun HttpClient.rSocket(
     request: HttpRequestBuilder.() -> Unit,
-): RSocket = rSocket(clientTransport(request))
+): RSocket = rSocket(WebSocketClientTransport(this, request))
 
 public suspend fun HttpClient.rSocket(
     urlString: String,
     secure: Boolean = false,
     request: HttpRequestBuilder.() -> Unit = {},
-): RSocket = rSocket(clientTransport(urlString, secure, request))
+): RSocket = rSocket(WebSocketClientTransport(this, urlString, secure, request))
 
 public suspend fun HttpClient.rSocket(
     host: String = "localhost", port: Int = DEFAULT_PORT, path: String = "/",
     secure: Boolean = false,
-): RSocket = rSocket(clientTransport(host, port, path, secure))
+): RSocket = rSocket(WebSocketClientTransport(this, host, port, path, secure))
 
 
 private suspend fun HttpClient.rSocket(

--- a/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/WebSocketClientTransport.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/WebSocketClientTransport.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:OptIn(TransportApi::class)
+@file:Suppress("FunctionName")
+
 package io.rsocket.kotlin.transport.ktor.client
 
 import io.ktor.client.*
@@ -24,19 +27,20 @@ import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 import io.rsocket.kotlin.transport.ktor.*
 
-@OptIn(TransportApi::class)
-internal fun HttpClient.clientTransport(
+public fun WebSocketClientTransport(
+    httpClient: HttpClient,
     request: HttpRequestBuilder.() -> Unit,
 ): ClientTransport = ClientTransport {
-    val session = webSocketSession(request)
+    val session = httpClient.webSocketSession(request)
     WebSocketConnection(session)
 }
 
-internal fun HttpClient.clientTransport(
+public fun WebSocketClientTransport(
+    httpClient: HttpClient,
     urlString: String,
     secure: Boolean = false,
     request: HttpRequestBuilder.() -> Unit = {},
-): ClientTransport = clientTransport {
+): ClientTransport = WebSocketClientTransport(httpClient) {
     url {
         protocol = if (secure) URLProtocol.WSS else URLProtocol.WS
         port = url.protocol.defaultPort
@@ -45,11 +49,12 @@ internal fun HttpClient.clientTransport(
     request()
 }
 
-internal fun HttpClient.clientTransport(
+public fun WebSocketClientTransport(
+    httpClient: HttpClient,
     host: String = "localhost", port: Int = DEFAULT_PORT, path: String = "/",
     secure: Boolean = false,
     request: HttpRequestBuilder.() -> Unit = {},
-): ClientTransport = clientTransport {
+): ClientTransport = WebSocketClientTransport(httpClient) {
     url {
         this.protocol = if (secure) URLProtocol.WSS else URLProtocol.WS
         this.port = port

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
@@ -31,9 +31,8 @@ import kotlinx.coroutines.channels.*
 import kotlin.coroutines.*
 import kotlin.native.concurrent.*
 
-//TODO is there a better way to ignore K/N exceptions
 @SharedImmutable
-private val ignoreExceptionHandler = CoroutineExceptionHandler { _, _ -> }
+internal val ignoreExceptionHandler = CoroutineExceptionHandler { _, _ -> }
 
 @OptIn(KtorExperimentalAPI::class, TransportApi::class, DangerousInternalIoApi::class)
 internal class TcpConnection(private val socket: Socket) : Connection, CoroutineScope {

--- a/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTest.kt
+++ b/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTest.kt
@@ -1,21 +1,48 @@
-package io.rsocket.kotlin
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.network.selector.*
-import io.ktor.network.sockets.*
+import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.test.*
-import io.rsocket.kotlin.transport.ktor.*
+import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
+import kotlin.random.*
 import kotlin.test.*
 
-class TcpServerTest : SuspendTest, TestWithLeakCheck {
+abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
+    private val clientSelector = SelectorManager()
+    private val serverSelector = SelectorManager()
+    private val currentPort = port.incrementAndGet()
+    private val serverTransport = TcpServerTransport(SelectorManager(), port = currentPort)
+    private val clientTransport = TcpClientTransport(SelectorManager(), "0.0.0.0", port = currentPort)
 
-    private val tcp = aSocket(ActorSelectorManager(Dispatchers.IO)).tcp()
+    private lateinit var server: Job
+
+    override suspend fun after() {
+        server.cancelAndJoin()
+        clientSelector.close()
+        serverSelector.close()
+    }
 
     @Test
     fun testFailedConnection() = test {
-        val server = tcp.serverTransport()
-        val job = RSocketServer().bind(server) {
+        server = RSocketServer().bind(serverTransport) {
             if (config.setupPayload.data.readText() == "ok") {
                 RSocketRequestHandler {
                     requestResponse { it }
@@ -29,7 +56,7 @@ class TcpServerTest : SuspendTest, TestWithLeakCheck {
                     payload(text)
                 }
             }
-        }.connect(tcp.clientTransport(server.socket.localAddress))
+        }.connect(clientTransport)
 
         val client1 = newClient("ok")
         client1.requestResponse(payload("ok")).release()
@@ -48,20 +75,19 @@ class TcpServerTest : SuspendTest, TestWithLeakCheck {
         assertFalse(client2.isActive)
         assertTrue(client3.isActive)
 
-        assertTrue(job.isActive)
+        assertTrue(server.isActive)
     }
 
     @Test
     fun testFailedHandler() = test {
-        val server = tcp.serverTransport()
         val handlers = mutableListOf<RSocket>()
-        val job = RSocketServer().bind(server) {
+        server = RSocketServer().bind(serverTransport) {
             RSocketRequestHandler {
                 requestResponse { it }
             }.also { handlers += it }
         }
 
-        suspend fun newClient() = RSocketConnector().connect(tcp.clientTransport(server.socket.localAddress))
+        suspend fun newClient() = RSocketConnector().connect(clientTransport)
 
         val client1 = newClient()
 
@@ -92,6 +118,10 @@ class TcpServerTest : SuspendTest, TestWithLeakCheck {
         assertFalse(client2.isActive)
         assertTrue(client3.isActive)
 
-        assertTrue(job.isActive)
+        assertTrue(server.isActive)
+    }
+
+    companion object {
+        private val port = atomic(Random.nextInt(20, 90) * 100)
     }
 }

--- a/rsocket-transport-ktor/src/jsMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
+++ b/rsocket-transport-ktor/src/jsMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
@@ -18,14 +18,15 @@ package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
+import kotlinx.coroutines.channels.*
 
 //TODO not needed for JS
 internal actual suspend fun ByteReadChannel.readExactPacket(length: Int): ByteReadPacket {
     val l = length.toLong()
     val packet = readRemaining(l)
-    require(packet.remaining == l) {
+    if (packet.remaining != l) {
         packet.release()
-        "Unexpected EOF: expected ${l - packet.remaining} more bytes"
+        throw ClosedReceiveChannelException("Unexpected EOF: expected ${l - packet.remaining} more bytes")
     }
     return packet
 }

--- a/rsocket-transport-ktor/src/jsMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
+++ b/rsocket-transport-ktor/src/jsMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.transport.ktor
+
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+
+//TODO not needed for JS
+internal actual suspend fun ByteReadChannel.readExactPacket(length: Int): ByteReadPacket {
+    val l = length.toLong()
+    val packet = readRemaining(l)
+    require(packet.remaining == l) {
+        packet.release()
+        "Unexpected EOF: expected ${l - packet.remaining} more bytes"
+    }
+    return packet
+}

--- a/rsocket-transport-ktor/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
+++ b/rsocket-transport-ktor/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.transport.ktor
+
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+
+internal actual suspend fun ByteReadChannel.readExactPacket(length: Int): ByteReadPacket = readPacket(length)

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/JvmTcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/JvmTcpTransportTest.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin
+package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.network.selector.*
-import io.rsocket.kotlin.transport.ktor.*
+import kotlinx.coroutines.*
 
-class NativeTcpTransportTest : TcpTransportTest(SelectorManager(), SelectorManager())
+class JvmTcpTransportTest : TcpTransportTest(ActorSelectorManager(Dispatchers.IO), ActorSelectorManager(Dispatchers.IO))
 
-class NativeTcpServerTest : TcpServerTest()
+class JvmTcpServerTest : TcpServerTest()

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin
+package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.application.*
 import io.ktor.client.*
 import io.ktor.routing.*
 import io.ktor.server.engine.*
+import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.payload.*

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketTransportTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketTransportTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin
+package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.application.*
 import io.ktor.client.*

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketTransportTests.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketTransportTests.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin
+package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.client.engine.okhttp.*
 import io.ktor.server.jetty.*

--- a/rsocket-transport-ktor/src/nativeMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
+++ b/rsocket-transport-ktor/src/nativeMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.transport.ktor
+
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
+
+internal actual suspend fun ByteReadChannel.readExactPacket(length: Int): ByteReadPacket {
+    val l = length.toLong()
+    val packet = readRemaining(l)
+    require(packet.remaining == l) {
+        packet.release()
+        "Unexpected EOF: expected ${l - packet.remaining} more bytes"
+    }
+    return packet
+}

--- a/rsocket-transport-ktor/src/nativeMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
+++ b/rsocket-transport-ktor/src/nativeMain/kotlin/io/rsocket/kotlin/transport/ktor/readExactPacket.kt
@@ -18,13 +18,14 @@ package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
+import kotlinx.coroutines.channels.*
 
 internal actual suspend fun ByteReadChannel.readExactPacket(length: Int): ByteReadPacket {
     val l = length.toLong()
     val packet = readRemaining(l)
-    require(packet.remaining == l) {
+    if (packet.remaining != l) {
         packet.release()
-        "Unexpected EOF: expected ${l - packet.remaining} more bytes"
+        throw ClosedReceiveChannelException("Unexpected EOF: expected ${l - packet.remaining} more bytes")
     }
     return packet
 }


### PR DESCRIPTION
* rework TCP ClientTransport creation for better support of freezing on K/N
* rework TCP ServerTransport creation:
  * create TCP server only on bind to RSocketServer
  * link socket job and started server
  * remove TcpServer class at all
* expose WebSocket client transport as `ClientTransport` interface for parity with tcp
* TCP server now exposed on K/N !!!
* introduce `readExactPacket` - because of [KTOR-2516](https://youtrack.jetbrains.com/issue/KTOR-2516), [KTOR-2519](https://youtrack.jetbrains.com/issue/KTOR-2519), fixes #145

Note: thx to fix for #145 K/N server is now working ok!