### PR TITLE
Compatibility improvements

### DIFF
--- a/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
+++ b/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlin.random.*
 
-@OptIn(ExperimentalStreamsApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalStreamsApi::class)
 class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
     private val requestStrategy = PrefetchStrategy(64, 0)
 

--- a/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
+++ b/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
@@ -20,7 +20,6 @@ import io.ktor.network.sockets.*
 import io.ktor.routing.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
-import io.ktor.util.*
 import io.ktor.websocket.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
@@ -32,7 +31,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.*
 
-@OptIn(KtorExperimentalAPI::class, ExperimentalSerializationApi::class, ExperimentalMetadataApi::class, InternalAPI::class)
+@OptIn(ExperimentalSerializationApi::class, ExperimentalMetadataApi::class, InternalAPI::class)
 fun main() {
     val proto = ConfiguredProtoBuf
     val users = Users()

--- a/playground/src/commonMain/kotlin/TCP.kt
+++ b/playground/src/commonMain/kotlin/TCP.kt
@@ -16,21 +16,18 @@
 
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.util.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.ktor.*
 import kotlin.coroutines.*
 
 
-@OptIn(KtorExperimentalAPI::class, InternalAPI::class)
 suspend fun runTcpClient(dispatcher: CoroutineContext) {
     val transport = TcpClientTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
     RSocketConnector().connect(transport).doSomething()
 }
 
 //to test nodejs tcp server
-@OptIn(KtorExperimentalAPI::class, InternalAPI::class)
 suspend fun testNodeJsServer(dispatcher: CoroutineContext) {
     val transport = TcpClientTransport(SelectorManager(dispatcher), "127.0.0.1", 9000)
     val client = RSocketConnector().connect(transport)

--- a/playground/src/commonMain/kotlin/WS.kt
+++ b/playground/src/commonMain/kotlin/WS.kt
@@ -17,10 +17,8 @@
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.features.websocket.*
-import io.ktor.util.*
 import io.rsocket.kotlin.transport.ktor.client.*
 
-@OptIn(KtorExperimentalAPI::class)
 suspend fun runWSClient(engine: HttpClientEngineFactory<*>) {
     val client = HttpClient(engine) {
         install(WebSockets)

--- a/playground/src/jvmMain/kotlin/WSServerApp.kt
+++ b/playground/src/jvmMain/kotlin/WSServerApp.kt
@@ -18,10 +18,8 @@ import io.ktor.application.*
 import io.ktor.routing.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
-import io.ktor.util.*
 import io.rsocket.kotlin.transport.ktor.server.*
 
-@OptIn(KtorExperimentalAPI::class)
 fun main() {
     embeddedServer(CIO) {
         install(RSocketSupport)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -71,8 +71,8 @@ public class RSocketConnectorBuilder internal constructor() {
     }
 
     public class ConnectionConfigBuilder internal constructor() {
-        public var keepAlive: KeepAlive = KeepAlive()
-        public var payloadMimeType: PayloadMimeType = PayloadMimeType()
+        public var keepAlive: KeepAlive = DefaultKeepAlive
+        public var payloadMimeType: PayloadMimeType = DefaultPayloadMimeType
         private var setupPayload: (() -> Payload)? = null
 
         public fun setupPayload(block: (() -> Payload)?) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/ReconnectableRSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/ReconnectableRSocket.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.*
 internal typealias ReconnectPredicate = suspend (cause: Throwable, attempt: Long) -> Boolean
 
 @Suppress("FunctionName")
-@OptIn(FlowPreview::class)
 internal suspend fun ReconnectableRSocket(
     logger: Logger,
     connect: suspend () -> RSocket,
@@ -35,7 +34,7 @@ internal suspend fun ReconnectableRSocket(
 ): RSocket {
     val job = Job()
     val state =
-        connect.asFlow()
+        flow { emit(connect()) }
             .map<RSocket, ReconnectState> { ReconnectState.Connected(it) } //if connection established - state = connected
             .onStart { emit(ReconnectState.Connecting) } //init - state = connecting
             .retryWhen { cause, attempt -> //reconnection logic

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/Version.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/Version.kt
@@ -18,12 +18,11 @@ package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
 
-internal fun Version(major: Int, minor: Int): Version = Version((major shl 16) or (minor and 0xFFFF))
+internal class Version(val major: Int, val minor: Int) {
+    val intValue: Int get() = (major shl 16) or (minor and 0xFFFF)
 
-@Suppress("EXPERIMENTAL_FEATURE_WARNING")
-internal inline class Version(val value: Int) {
-    val major: Int get() = value shr 16 and 0xFFFF
-    val minor: Int get() = value and 0xFFFF
+    override fun equals(other: Any?): Boolean = other is Version && intValue == other.intValue
+    override fun hashCode(): Int = intValue
     override fun toString(): String = "$major.$minor"
 
     companion object {
@@ -31,8 +30,14 @@ internal inline class Version(val value: Int) {
     }
 }
 
-internal fun ByteReadPacket.readVersion(): Version = Version(readInt())
+internal fun ByteReadPacket.readVersion(): Version {
+    val value = readInt()
+    return Version(
+        major = value shr 16 and 0xFFFF,
+        minor = value and 0xFFFF
+    )
+}
 
 internal fun BytePacketBuilder.writeVersion(version: Version) {
-    writeInt(version.value)
+    writeInt(version.intValue)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/IntMap.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/IntMap.kt
@@ -103,19 +103,21 @@ internal class IntMap<V : Any>(initialCapacity: Int = 8, private val loadFactor:
             store.clearSize()
         }
 
-        @OptIn(ExperimentalStdlibApi::class)
-        fun values(): List<V> = buildList {
+        fun values(): List<V> {
+            val list = mutableListOf<V>()
             repeat(capacity) {
-                store.value(it)?.let(this::add)
+                store.value(it)?.let(list::add)
             }
+            return list.toList()
         }
 
-        @OptIn(ExperimentalStdlibApi::class)
-        fun keys(): Set<Int> = buildSet {
+        fun keys(): Set<Int> {
+            val set = mutableSetOf<Int>()
             repeat(capacity) {
                 val key = store.key(it)
-                if (this@MapState.contains(key)) add(key)
+                if (this@MapState.contains(key)) set.add(key)
             }
+            return set.toSet()
         }
 
         private fun set(index: Int, key: Int, value: V?) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketState.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketState.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
 
 @OptIn(
-    InternalCoroutinesApi::class,
     TransportApi::class,
     ExperimentalStreamsApi::class
 )
@@ -97,7 +96,7 @@ internal class RSocketState(
         limits[streamId] = limitingCollector
         try {
             onStart()
-            collect(limitingCollector)
+            limitingCollector.emitAll(this@collectLimiting)
             send(CompletePayloadFrame(streamId))
         } catch (e: Throwable) {
             limits.remove(streamId)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/flow/RequestChannelRequesterFlow.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/flow/RequestChannelRequesterFlow.kt
@@ -24,7 +24,7 @@ import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 
-@OptIn(ExperimentalStreamsApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalStreamsApi::class)
 internal class RequestChannelRequesterFlow(
     private val initPayload: Payload,
     private val payloads: Flow<Payload>,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/keepalive/KeepAlive.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/keepalive/KeepAlive.kt
@@ -16,9 +16,25 @@
 
 package io.rsocket.kotlin.keepalive
 
+import kotlin.native.concurrent.*
 import kotlin.time.*
 
-data class KeepAlive @OptIn(ExperimentalTime::class) constructor(
-    val interval: Duration = 20.seconds,
-    val maxLifetime: Duration = 90.seconds
+@ExperimentalTime
+public fun KeepAlive(
+    interval: Duration = 20.seconds,
+    maxLifetime: Duration = 90.seconds
+): KeepAlive = KeepAlive(
+    intervalMillis = interval.toInt(DurationUnit.MILLISECONDS),
+    maxLifetimeMillis = maxLifetime.toInt(DurationUnit.MILLISECONDS)
+)
+
+public class KeepAlive(
+    public val intervalMillis: Int = 20 * 1000, // 20 seconds
+    public val maxLifetimeMillis: Int = 90 * 1000 // 90 seconds
+)
+
+@SharedImmutable
+internal val DefaultKeepAlive = KeepAlive(
+    intervalMillis = 20 * 1000, // 20 seconds
+    maxLifetimeMillis = 90 * 1000 // 90 seconds
 )

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
@@ -52,15 +52,16 @@ public interface CompositeMetadata : Metadata {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketCompositeMetadata
 
         @DangerousInternalIoApi
-        @OptIn(ExperimentalStdlibApi::class)
-        override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): CompositeMetadata = DefaultCompositeMetadata(buildList {
+        override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): CompositeMetadata {
+            val list = mutableListOf<Entry>()
             while (isNotEmpty) {
                 val type = readMimeType()
                 val length = readLength()
                 val packet = readPacket(pool, length)
-                add(Entry(type, packet))
+                list.add(Entry(type, packet))
             }
-        })
+            return DefaultCompositeMetadata(list.toList())
+        }
     }
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
@@ -41,10 +41,10 @@ public class PerStreamAcceptableDataMimeTypesMetadata(public val types: List<Mim
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAcceptMimeTypes
 
         @DangerousInternalIoApi
-        @OptIn(ExperimentalStdlibApi::class)
-        override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): PerStreamAcceptableDataMimeTypesMetadata =
-            PerStreamAcceptableDataMimeTypesMetadata(buildList {
-                while (isNotEmpty) add(readMimeType())
-            })
+        override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): PerStreamAcceptableDataMimeTypesMetadata {
+            val list = mutableListOf<MimeType>()
+            while (isNotEmpty) list.add(readMimeType())
+            return PerStreamAcceptableDataMimeTypesMetadata(list.toList())
+        }
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
@@ -47,12 +47,13 @@ public class RoutingMetadata(public val tags: List<String>) : Metadata {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketRouting
 
         @DangerousInternalIoApi
-        @OptIn(ExperimentalStdlibApi::class, ExperimentalUnsignedTypes::class)
-        override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): RoutingMetadata = RoutingMetadata(buildList {
+        override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): RoutingMetadata {
+            val list = mutableListOf<String>()
             while (isNotEmpty) {
-                val length = readUByte().toInt()
-                add(readTextExactBytes(length))
+                val length = readByte().toInt() and 0xFF
+                list.add(readTextExactBytes(length))
             }
-        })
+            return RoutingMetadata(list.toList())
+        }
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/PayloadMimeType.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/PayloadMimeType.kt
@@ -18,10 +18,16 @@ package io.rsocket.kotlin.payload
 
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
+import kotlin.native.concurrent.*
 
-data class PayloadMimeType(
-    val data: String = "application/binary",
-    val metadata: String = "application/binary",
+public fun PayloadMimeType(
+    data: MimeTypeWithName,
+    metadata: MimeTypeWithName,
+): PayloadMimeType = PayloadMimeType(data.text, metadata.text)
+
+public class PayloadMimeType(
+    public val data: String,
+    public val metadata: String,
 ) {
     init {
         data.requireAscii()
@@ -29,7 +35,8 @@ data class PayloadMimeType(
     }
 }
 
-public fun PayloadMimeType(
-    data: MimeTypeWithName,
-    metadata: MimeTypeWithName,
-): PayloadMimeType = PayloadMimeType(data.text, metadata.text)
+@SharedImmutable
+internal val DefaultPayloadMimeType = PayloadMimeType(
+    data = WellKnownMimeType.ApplicationOctetStream,
+    metadata = WellKnownMimeType.ApplicationOctetStream
+)

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/SetupRejectionTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/SetupRejectionTest.kt
@@ -43,7 +43,7 @@ class SetupRejectionTest : SuspendTest, TestWithLeakCheck {
             error(errorMessage)
         }
 
-        connection.sendToReceiver(SetupFrame(Version.Current, false, KeepAlive(), null, PayloadMimeType(), Payload.Empty))
+        connection.sendToReceiver(SetupFrame(Version.Current, false, DefaultKeepAlive, null, DefaultPayloadMimeType, Payload.Empty))
 
         assertFailsWith(RSocketError.Setup.Rejected::class, errorMessage) { deferred.await() }
 

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/SetupFrameTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/SetupFrameTest.kt
@@ -17,6 +17,7 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.payload.*
@@ -28,7 +29,7 @@ class SetupFrameTest : TestWithLeakCheck {
 
     private val version = Version.Current
     private val keepAlive = KeepAlive(10.seconds, 500.seconds)
-    private val payloadMimeType = PayloadMimeType("")
+    private val payloadMimeType = PayloadMimeType(WellKnownMimeType.ApplicationOctetStream, CustomMimeType("mime"))
 
     @Test
     fun testNoResumeEmptyPayload() {
@@ -39,9 +40,11 @@ class SetupFrameTest : TestWithLeakCheck {
         assertEquals(0, decodedFrame.streamId)
         assertEquals(version, decodedFrame.version)
         assertTrue(decodedFrame.honorLease)
-        assertEquals(keepAlive, decodedFrame.keepAlive)
+        assertEquals(keepAlive.intervalMillis, decodedFrame.keepAlive.intervalMillis)
+        assertEquals(keepAlive.maxLifetimeMillis, decodedFrame.keepAlive.maxLifetimeMillis)
         assertNull(decodedFrame.resumeToken)
-        assertEquals(payloadMimeType, decodedFrame.payloadMimeType)
+        assertEquals(payloadMimeType.data, decodedFrame.payloadMimeType.data)
+        assertEquals(payloadMimeType.metadata, decodedFrame.payloadMimeType.metadata)
         assertEquals(0, decodedFrame.payload.data.remaining)
         assertNull(decodedFrame.payload.metadata)
     }
@@ -56,9 +59,11 @@ class SetupFrameTest : TestWithLeakCheck {
         assertEquals(0, decodedFrame.streamId)
         assertEquals(version, decodedFrame.version)
         assertTrue(decodedFrame.honorLease)
-        assertEquals(keepAlive, decodedFrame.keepAlive)
+        assertEquals(keepAlive.intervalMillis, decodedFrame.keepAlive.intervalMillis)
+        assertEquals(keepAlive.maxLifetimeMillis, decodedFrame.keepAlive.maxLifetimeMillis)
         assertNull(decodedFrame.resumeToken)
-        assertEquals(payloadMimeType, decodedFrame.payloadMimeType)
+        assertEquals(payloadMimeType.data, decodedFrame.payloadMimeType.data)
+        assertEquals(payloadMimeType.metadata, decodedFrame.payloadMimeType.metadata)
         assertBytesEquals(ByteArray(30000) { 1 }, decodedFrame.payload.data.readBytes())
         assertBytesEquals(ByteArray(20000) { 5 }, decodedFrame.payload.metadata?.readBytes())
     }
@@ -73,9 +78,11 @@ class SetupFrameTest : TestWithLeakCheck {
         assertEquals(0, decodedFrame.streamId)
         assertEquals(version, decodedFrame.version)
         assertTrue(decodedFrame.honorLease)
-        assertEquals(keepAlive, decodedFrame.keepAlive)
+        assertEquals(keepAlive.intervalMillis, decodedFrame.keepAlive.intervalMillis)
+        assertEquals(keepAlive.maxLifetimeMillis, decodedFrame.keepAlive.maxLifetimeMillis)
         assertBytesEquals(ByteArray(65000) { 5 }, decodedFrame.resumeToken?.readBytes())
-        assertEquals(payloadMimeType, decodedFrame.payloadMimeType)
+        assertEquals(payloadMimeType.data, decodedFrame.payloadMimeType.data)
+        assertEquals(payloadMimeType.metadata, decodedFrame.payloadMimeType.metadata)
         assertEquals(0, decodedFrame.payload.data.remaining)
         assertNull(decodedFrame.payload.metadata)
     }
@@ -91,9 +98,11 @@ class SetupFrameTest : TestWithLeakCheck {
         assertEquals(0, decodedFrame.streamId)
         assertEquals(version, decodedFrame.version)
         assertTrue(decodedFrame.honorLease)
-        assertEquals(keepAlive, decodedFrame.keepAlive)
+        assertEquals(keepAlive.intervalMillis, decodedFrame.keepAlive.intervalMillis)
+        assertEquals(keepAlive.maxLifetimeMillis, decodedFrame.keepAlive.maxLifetimeMillis)
         assertBytesEquals(ByteArray(65000) { 5 }, decodedFrame.resumeToken?.readBytes())
-        assertEquals(payloadMimeType, decodedFrame.payloadMimeType)
+        assertEquals(payloadMimeType.data, decodedFrame.payloadMimeType.data)
+        assertEquals(payloadMimeType.metadata, decodedFrame.payloadMimeType.metadata)
         assertBytesEquals(ByteArray(30000) { 1 }, decodedFrame.payload.data.readBytes())
         assertBytesEquals(ByteArray(20000) { 5 }, decodedFrame.payload.metadata?.readBytes())
     }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/io/VersionTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/io/VersionTest.kt
@@ -25,7 +25,7 @@ class VersionTest {
         val version = Version(1, 0)
         assertEquals(1, version.major)
         assertEquals(0, version.minor)
-        assertEquals(0x00010000, version.value)
+        assertEquals(0x00010000, version.intValue)
         assertEquals("1.0", version.toString())
     }
 
@@ -34,7 +34,7 @@ class VersionTest {
         val version = Version(0x1234, 0x5678)
         assertEquals(0x1234, version.major)
         assertEquals(0x5678, version.minor)
-        assertEquals(0x12345678, version.value)
+        assertEquals(0x12345678, version.intValue)
         assertEquals("4660.22136", version.toString())
     }
 

--- a/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/keepalive/currentMillis.kt
+++ b/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/keepalive/currentMillis.kt
@@ -14,15 +14,8 @@
  * limitations under the License.
  */
 
-import io.ktor.network.selector.*
-import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.transport.ktor.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
+package io.rsocket.kotlin.keepalive
 
-suspend fun runTcpServer(dispatcher: CoroutineContext) {
-    val transport = TcpServerTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
-    RSocketServer().bind(transport, rSocketAcceptor).join()
-}
+import kotlin.js.*
 
-suspend fun main(): Unit = runTcpServer(Dispatchers.IO)
+internal actual fun currentMillis(): Long = Date.now().toLong()

--- a/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/keepalive/currentMillis.kt
+++ b/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/keepalive/currentMillis.kt
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-import io.ktor.network.selector.*
-import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.transport.ktor.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
+package io.rsocket.kotlin.keepalive
 
-suspend fun runTcpServer(dispatcher: CoroutineContext) {
-    val transport = TcpServerTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
-    RSocketServer().bind(transport, rSocketAcceptor).join()
-}
-
-suspend fun main(): Unit = runTcpServer(Dispatchers.IO)
+internal actual fun currentMillis(): Long = System.currentTimeMillis()

--- a/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/keepalive/currentMillis.kt
+++ b/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/keepalive/currentMillis.kt
@@ -14,15 +14,8 @@
  * limitations under the License.
  */
 
-import io.ktor.network.selector.*
-import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.transport.ktor.*
-import kotlinx.coroutines.*
-import kotlin.coroutines.*
+package io.rsocket.kotlin.keepalive
 
-suspend fun runTcpServer(dispatcher: CoroutineContext) {
-    val transport = TcpServerTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
-    RSocketServer().bind(transport, rSocketAcceptor).join()
-}
+import kotlin.system.*
 
-suspend fun main(): Unit = runTcpServer(Dispatchers.IO)
+internal actual fun currentMillis(): Long = getTimeMillis()

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.*
 import kotlin.test.*
 import kotlin.time.*
 
-@OptIn(ExperimentalTime::class)
 abstract class TransportTest : SuspendTest, TestWithLeakCheck {
     override val testTimeout: Duration = TransportTestDefaultDuration
 

--- a/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/RSocketSupport.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/RSocketSupport.kt
@@ -37,7 +37,6 @@ public class RSocketSupport(
             return RSocketSupport(connector)
         }
 
-        @OptIn(KtorExperimentalAPI::class)
         override fun install(feature: RSocketSupport, scope: HttpClient) {
             scope.feature(WebSockets) ?: error("RSocket require WebSockets to work. You must install WebSockets feature first.")
         }

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
@@ -17,7 +17,6 @@
 package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.network.sockets.*
-import io.ktor.util.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
@@ -34,7 +33,7 @@ import kotlin.native.concurrent.*
 @SharedImmutable
 internal val ignoreExceptionHandler = CoroutineExceptionHandler { _, _ -> }
 
-@OptIn(KtorExperimentalAPI::class, TransportApi::class, DangerousInternalIoApi::class)
+@OptIn(TransportApi::class, DangerousInternalIoApi::class)
 internal class TcpConnection(private val socket: Socket) : Connection, CoroutineScope {
     override val job: CompletableJob = Job(socket.socketContext)
     override val coroutineContext: CoroutineContext = job + Dispatchers.Unconfined + ignoreExceptionHandler


### PR DESCRIPTION
* remove FlowPreview, InternalCoroutinesApi, ExperimentalCoroutinesApi, ExperimentalStdlibApi, ExperimentalUnsignedTypes, ExperimentalTime, KtorExperimentalAPI opt-in usage
* use ordinary class instead of inline for Version
* rewrite KeepAlive to use experimental time only in one place with appropriate annotation, don't use data class
* minor rewrite of PayloadMimeType - change default mime type to "application/octet-stream", don't use data class

fixes #151 