### PR TITLE
fix jvm tcp freeze in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,9 @@ subprojects {
                 testRuns.all {
                     executionTask.configure {
                         enabled = isMainHost
-                        jvmArgs("-Xmx4g", "-XX:+UseParallelGC")
+                        // ActiveProcessorCount is used here, to make sure local setup is similar as on CI
+                        // Github Actions linux runners have 2 cores
+                        jvmArgs("-Xmx4g", "-XX:+UseParallelGC", "-XX:ActiveProcessorCount=2")
                     }
                 }
             }

--- a/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTest.kt
+++ b/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTest.kt
@@ -25,12 +25,13 @@ import kotlinx.coroutines.*
 import kotlin.random.*
 import kotlin.test.*
 
-abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
-    private val clientSelector = SelectorManager()
-    private val serverSelector = SelectorManager()
+abstract class TcpServerTest(
+    private val clientSelector: SelectorManager,
+    private val serverSelector: SelectorManager
+) : SuspendTest, TestWithLeakCheck {
     private val currentPort = port.incrementAndGet()
-    private val serverTransport = TcpServerTransport(SelectorManager(), port = currentPort)
-    private val clientTransport = TcpClientTransport(SelectorManager(), "0.0.0.0", port = currentPort)
+    private val serverTransport = TcpServerTransport(serverSelector, port = currentPort)
+    private val clientTransport = TcpClientTransport(clientSelector, "0.0.0.0", port = currentPort)
 
     private lateinit var server: Job
 
@@ -76,6 +77,10 @@ abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
         assertTrue(client3.isActive)
 
         assertTrue(server.isActive)
+
+        client1.job.cancelAndJoin()
+        client2.job.cancelAndJoin()
+        client3.job.cancelAndJoin()
     }
 
     @Test
@@ -119,6 +124,10 @@ abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
         assertTrue(client3.isActive)
 
         assertTrue(server.isActive)
+
+        client1.job.cancelAndJoin()
+        client2.job.cancelAndJoin()
+        client3.job.cancelAndJoin()
     }
 
     companion object {

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/JvmTcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/JvmTcpTransportTest.kt
@@ -21,4 +21,4 @@ import kotlinx.coroutines.*
 
 class JvmTcpTransportTest : TcpTransportTest(ActorSelectorManager(Dispatchers.IO), ActorSelectorManager(Dispatchers.IO))
 
-class JvmTcpServerTest : TcpServerTest()
+class JvmTcpServerTest : TcpServerTest(ActorSelectorManager(Dispatchers.IO), ActorSelectorManager(Dispatchers.IO))

--- a/rsocket-transport-ktor/src/nativeTest/kotlin/io/rsocket/kotlin/NativeTcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/nativeTest/kotlin/io/rsocket/kotlin/NativeTcpTransportTest.kt
@@ -21,4 +21,4 @@ import io.rsocket.kotlin.transport.ktor.*
 
 class NativeTcpTransportTest : TcpTransportTest(SelectorManager(), SelectorManager())
 
-class NativeTcpServerTest : TcpServerTest()
+class NativeTcpServerTest : TcpServerTest(SelectorManager(), SelectorManager())


### PR DESCRIPTION
accidentally TCP tests on JVM were broken in #149 :(
in `TcpServerTest`, additional selectors were created using Default dispatcher and not closed. and as so, after test finished, coroutines will continue working and block threads.
Locally it was not reproducible on my side, as I have 8 cores, but CI has only 2 cores, so I've aligned tests JVM parameters to have better local reproducibility.