### PR TITLE
Kotlin 1.5 upgrade (dupe/redo)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ subprojects {
             jvm {
                 compilations.all {
                     kotlinOptions {
-                        jvmTarget = "1.6"
+                        jvmTarget = "1.8"
                         useIR = true
                     }
                 }
@@ -156,8 +156,8 @@ subprojects {
             sourceSets.all {
                 languageSettings.apply {
                     progressiveMode = true
-                    languageVersion = "1.4"
-                    apiVersion = "1.4"
+                    languageVersion = "1.5"
+                    apiVersion = "1.5"
 
                     useExperimentalAnnotation("kotlin.RequiresOptIn")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,14 +19,14 @@ group=io.rsocket.kotlin
 version=0.13.0
 
 #Versions
-kotlinVersion=1.4.32
+kotlinVersion=1.5.10
 ktorVersion=1.5.4
-kotlinxCoroutinesVersion=1.4.3-native-mt
-kotlinxAtomicfuVersion=0.15.2
-kotlinxSerializationVersion=1.1.0
-kotlinxBenchmarkVersion=0.3.0
+kotlinxCoroutinesVersion=1.5.0-native-mt
+kotlinxAtomicfuVersion=0.16.1
+kotlinxSerializationVersion=1.2.1
+kotlinxBenchmarkVersion=0.3.1
 kotlinxNodejsVersion=0.0.7
-rsocketJavaVersion=1.1.0
+rsocketJavaVersion=1.1.1
 turbineVersion=0.4.1
 bintrayVersion=1.8.5
 artifactoryVersion=4.18.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
fresh start at 1.5.0 migration.  potential dupe of https://github.com/rsocket/rsocket-kotlin/compare/task/kotlin-1.5.0