### PR TITLE
cleanups general code and public API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,8 +162,8 @@ subprojects {
                         useExperimentalAnnotation("kotlinx.coroutines.InternalCoroutinesApi")
                         useExperimentalAnnotation("kotlinx.coroutines.ObsoleteCoroutinesApi")
                         useExperimentalAnnotation("kotlinx.coroutines.FlowPreview")
+                        useExperimentalAnnotation("kotlinx.coroutines.DelicateCoroutinesApi")
 
-                        useExperimentalAnnotation("io.ktor.util.KtorExperimentalAPI")
                         useExperimentalAnnotation("io.ktor.util.InternalAPI")
                         useExperimentalAnnotation("io.ktor.utils.io.core.internal.DangerousInternalIoApi")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import groovy.util.Node
-import groovy.util.NodeList
-import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
+import groovy.util.*
+import org.gradle.api.publish.maven.internal.artifact.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.konan.target.*
@@ -205,8 +204,10 @@ subprojects {
     }
 }
 
-fun publishPlatformArtifactsInRootModule(platformPublication:MavenPublication,
-                                         kotlinMultiplatformPublication: MavenPublication) {
+fun publishPlatformArtifactsInRootModule(
+    platformPublication: MavenPublication,
+    kotlinMultiplatformPublication: MavenPublication
+) {
     lateinit var platformXml: XmlProvider
 
     platformPublication.pom.withXml { platformXml = this }
@@ -313,7 +314,7 @@ subprojects {
             dependsOn(tasks.withType<Sign>())
         }
 
-        tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication"}.configureEach {
+        tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }.configureEach {
             dependsOn(tasks["generatePomFileForJvmPublication"])
         }
     }
@@ -422,7 +423,7 @@ if (sonatypeUsername != null && sonatypePassword != null) {
                                         it
                                     )
                                 }
-                                else -> it.artifactId = "${project.name}-$type"
+                                else                  -> it.artifactId = "${project.name}-$type"
                             }
                         }
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,12 +170,13 @@ subprojects {
                         useExperimentalAnnotation("io.rsocket.kotlin.TransportApi")
                         useExperimentalAnnotation("io.rsocket.kotlin.ExperimentalMetadataApi")
                         useExperimentalAnnotation("io.rsocket.kotlin.ExperimentalStreamsApi")
+                        useExperimentalAnnotation("io.rsocket.kotlin.RSocketLoggingApi")
                     }
                 }
             }
 
             if (isLibProject && !isTestProject) {
-                explicitApiWarning() //TODO change to strict before release
+                explicitApi()
                 sourceSets["commonTest"].dependencies {
                     implementation(project(":rsocket-test"))
                 }

--- a/examples/interactions/src/jvmMain/kotlin/RequestResponseErrorExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/RequestResponseErrorExample.kt
@@ -16,7 +16,6 @@
 
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.local.*
 import kotlinx.coroutines.*
 

--- a/examples/interactions/src/jvmMain/kotlin/RequestResponseExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/RequestResponseExample.kt
@@ -16,7 +16,6 @@
 
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.local.*
 import kotlinx.coroutines.*
 

--- a/examples/interactions/src/jvmMain/kotlin/ServerRequestExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/ServerRequestExample.kt
@@ -16,7 +16,6 @@
 
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.local.*
 import kotlinx.coroutines.*
 

--- a/examples/multiplatform-chat/src/clientMain/kotlin/Api.kt
+++ b/examples/multiplatform-chat/src/clientMain/kotlin/Api.kt
@@ -17,7 +17,6 @@
 import io.ktor.client.*
 import io.ktor.client.features.websocket.*
 import io.ktor.network.selector.*
-import io.ktor.network.sockets.*
 import io.ktor.util.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*

--- a/examples/multiplatform-chat/src/clientMain/kotlin/ChatApi.kt
+++ b/examples/multiplatform-chat/src/clientMain/kotlin/ChatApi.kt
@@ -16,7 +16,6 @@
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.payload.*
 import kotlinx.serialization.*
 import kotlinx.serialization.protobuf.*
 

--- a/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
+++ b/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
@@ -16,7 +16,6 @@
 
 import io.ktor.application.*
 import io.ktor.network.selector.*
-import io.ktor.network.sockets.*
 import io.ktor.routing.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*

--- a/examples/nodejs-tcp-transport/src/jsMain/kotlin/Server.kt
+++ b/examples/nodejs-tcp-transport/src/jsMain/kotlin/Server.kt
@@ -18,7 +18,6 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.js.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*

--- a/examples/nodejs-tcp-transport/src/jsMain/kotlin/Server.kt
+++ b/examples/nodejs-tcp-transport/src/jsMain/kotlin/Server.kt
@@ -145,3 +145,17 @@ class NodeJsTcpConnection(private val socket: Socket) : Connection {
         return receiveChannel.receive()
     }
 }
+
+private fun ByteReadPacket.readLength(): Int {
+    val b = readByte().toInt() and 0xFF shl 16
+    val b1 = readByte().toInt() and 0xFF shl 8
+    val b2 = readByte().toInt() and 0xFF
+    return b or b1 or b2
+}
+
+private fun BytePacketBuilder.writeLength(length: Int) {
+    require(length and 0xFFFFFF.inv() == 0) { "Length is larger than 24 bits" }
+    writeByte((length shr 16).toByte())
+    writeByte((length shr 8).toByte())
+    writeByte(length.toByte())
+}

--- a/playground/src/commonMain/kotlin/TCP.kt
+++ b/playground/src/commonMain/kotlin/TCP.kt
@@ -15,7 +15,6 @@
  */
 
 import io.ktor.network.selector.*
-import io.ktor.network.sockets.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.ktor.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Annotations.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Annotations.kt
@@ -37,3 +37,12 @@ public annotation class ExperimentalMetadataApi
     message = "This is an API to customize request strategy of streams. This API can change in future in non backwards-compatible manner."
 )
 public annotation class ExperimentalStreamsApi
+
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This is mostly internal API used for logging. This API can change in future in non backwards-compatible manner."
+)
+public annotation class RSocketLoggingApi
+
+

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
@@ -30,18 +30,16 @@ import kotlinx.coroutines.*
 public interface Connection {
     public val job: Job
 
-    @DangerousInternalIoApi
-    public val pool: ObjectPool<ChunkBuffer>
-        get() = ChunkBuffer.Pool
+    public val pool: ObjectPool<ChunkBuffer> get() = ChunkBuffer.Pool
 
     public suspend fun send(packet: ByteReadPacket)
     public suspend fun receive(): ByteReadPacket
 }
 
-@OptIn(DangerousInternalIoApi::class, TransportApi::class)
+@OptIn(TransportApi::class)
 internal suspend fun Connection.receiveFrame(): Frame = receive().readFrame(pool)
 
-@OptIn(DangerousInternalIoApi::class, TransportApi::class)
+@OptIn(TransportApi::class)
 internal suspend fun Connection.sendFrame(frame: Frame) {
     val packet = frame.toPacket(pool)
     packet.closeOnError { send(packet) }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/ConnectionAcceptor.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/ConnectionAcceptor.kt
@@ -19,17 +19,9 @@ package io.rsocket.kotlin
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.payload.*
 
-
-//TODO fun interfaces don't support `suspend` functions for now... (seems will work in kotlin 1.5)
-
-public interface ConnectionAcceptor {
+public fun interface ConnectionAcceptor {
     public suspend fun ConnectionAcceptorContext.accept(): RSocket
 }
-
-public inline fun ConnectionAcceptor(crossinline block: suspend ConnectionAcceptorContext.() -> RSocket): ConnectionAcceptor =
-    object : ConnectionAcceptor {
-        override suspend fun ConnectionAcceptorContext.accept(): RSocket = block()
-    }
 
 public class ConnectionAcceptorContext internal constructor(
     public val config: ConnectionConfig,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketError.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketError.kt
@@ -46,8 +46,8 @@ public sealed class RSocketError(public val errorCode: Int, message: String) : T
             public const val MinAllowedCode: Int = ErrorCode.CustomMin
             public const val MaxAllowedCode: Int = ErrorCode.CustomMax
 
-            public inline fun checkCodeInAllowedRange(errorCode: Int): Boolean =
-                    MinAllowedCode <= errorCode || errorCode <= MaxAllowedCode
+            public fun checkCodeInAllowedRange(errorCode: Int): Boolean =
+                MinAllowedCode <= errorCode || errorCode <= MaxAllowedCode
         }
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketError.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketError.kt
@@ -55,7 +55,7 @@ public sealed class RSocketError(public val errorCode: Int, message: String) : T
 @Suppress("FunctionName") // function name intentionally starts with an uppercase letter
 internal fun RSocketError(streamId: Int, errorCode: Int, message: String): Throwable =
     when (streamId) {
-        0 -> when (errorCode) {
+        0    -> when (errorCode) {
             ErrorCode.InvalidSetup     -> RSocketError.Setup.Invalid(message)
             ErrorCode.UnsupportedSetup -> RSocketError.Setup.Unsupported(message)
             ErrorCode.RejectedSetup    -> RSocketError.Setup.Rejected(message)
@@ -66,11 +66,11 @@ internal fun RSocketError(streamId: Int, errorCode: Int, message: String): Throw
         }
         else -> when (errorCode) {
             ErrorCode.ApplicationError -> RSocketError.ApplicationError(message)
-            ErrorCode.Rejected -> RSocketError.Rejected(message)
-            ErrorCode.Canceled -> RSocketError.Canceled(message)
-            ErrorCode.Invalid -> RSocketError.Invalid(message)
-            else -> when (RSocketError.Custom.checkCodeInAllowedRange(errorCode)) {
-                true -> RSocketError.Custom(errorCode, message)
+            ErrorCode.Rejected         -> RSocketError.Rejected(message)
+            ErrorCode.Canceled         -> RSocketError.Canceled(message)
+            ErrorCode.Invalid          -> RSocketError.Invalid(message)
+            else                       -> when (RSocketError.Custom.checkCodeInAllowedRange(errorCode)) {
+                true  -> RSocketError.Custom(errorCode, message)
                 false -> IllegalArgumentException("Invalid Error frame in Stream ID $streamId: $errorCode '$message'")
             }
         }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/MimeType.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/MimeType.kt
@@ -18,13 +18,13 @@ package io.rsocket.kotlin.core
 
 import io.rsocket.kotlin.frame.io.*
 
-public interface MimeType
+public sealed interface MimeType
 
-public interface MimeTypeWithName : MimeType {
+public sealed interface MimeTypeWithName : MimeType {
     public val text: String
 }
 
-public interface MimeTypeWithId : MimeType {
+public sealed interface MimeTypeWithId : MimeType {
     public val identifier: Byte
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.core
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -23,7 +23,7 @@ import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 
-@OptIn(TransportApi::class)
+@OptIn(TransportApi::class, RSocketLoggingApi::class)
 class RSocketConnector internal constructor(
     private val loggerFactory: LoggerFactory,
     private val interceptors: Interceptors,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -24,7 +24,7 @@ import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 
 @OptIn(TransportApi::class, RSocketLoggingApi::class)
-class RSocketConnector internal constructor(
+public class RSocketConnector internal constructor(
     private val loggerFactory: LoggerFactory,
     private val interceptors: Interceptors,
     private val connectionConfigProvider: () -> ConnectionConfig,
@@ -32,7 +32,7 @@ class RSocketConnector internal constructor(
     private val reconnectPredicate: ReconnectPredicate?,
 ) {
 
-    suspend fun connect(transport: ClientTransport): RSocket = when (reconnectPredicate) {
+    public suspend fun connect(transport: ClientTransport): RSocket = when (reconnectPredicate) {
         null -> connectOnce(transport)
         else -> ReconnectableRSocket(
             logger = loggerFactory.logger("io.rsocket.kotlin.connection"),

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -24,6 +24,7 @@ import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 
 public class RSocketConnectorBuilder internal constructor() {
+    @RSocketLoggingApi
     public var loggerFactory: LoggerFactory = DefaultLoggerFactory
 
     private val connectionConfig: ConnectionConfigBuilder = ConnectionConfigBuilder()
@@ -92,6 +93,7 @@ public class RSocketConnectorBuilder internal constructor() {
         }
     }
 
+    @OptIn(RSocketLoggingApi::class)
     internal fun build(): RSocketConnector = RSocketConnector(
         loggerFactory,
         interceptors.build(),

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -42,10 +42,6 @@ public class RSocketConnectorBuilder internal constructor() {
         acceptor = block
     }
 
-    public fun acceptor(block: suspend ConnectionAcceptorContext.() -> RSocket) {
-        acceptor(ConnectionAcceptor(block))
-    }
-
     /**
      * When configured, [RSocketConnector.connect] will return custom [RSocket] implementation,
      * which will try to reconnect if connection lost and [retries] are not exhausted with [predicate] returning `true`.

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -17,6 +17,7 @@
 package io.rsocket.kotlin.core
 
 import io.rsocket.kotlin.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.payload.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -23,7 +23,7 @@ import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 
-@OptIn(TransportApi::class)
+@OptIn(TransportApi::class, RSocketLoggingApi::class)
 public class RSocketServer internal constructor(
     private val loggerFactory: LoggerFactory,
     private val interceptors: Interceptors,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.core
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -31,11 +31,6 @@ public class RSocketServer internal constructor(
 
     public fun <T> bind(
         transport: ServerTransport<T>,
-        block: suspend ConnectionAcceptorContext.() -> RSocket
-    ): T = bind(transport, ConnectionAcceptor(block))
-
-    public fun <T> bind(
-        transport: ServerTransport<T>,
         acceptor: ConnectionAcceptor,
     ): T = transport.start {
         val connection = it.wrapConnection()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServerBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServerBuilder.kt
@@ -16,9 +16,11 @@
 
 package io.rsocket.kotlin.core
 
+import io.rsocket.kotlin.*
 import io.rsocket.kotlin.logging.*
 
 public class RSocketServerBuilder internal constructor() {
+    @RSocketLoggingApi
     public var loggerFactory: LoggerFactory = DefaultLoggerFactory
 
     private val interceptors: InterceptorsBuilder = InterceptorsBuilder()
@@ -27,6 +29,7 @@ public class RSocketServerBuilder internal constructor() {
         interceptors.configure()
     }
 
+    @OptIn(RSocketLoggingApi::class)
     internal fun build(): RSocketServer = RSocketServer(loggerFactory, interceptors.build())
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/CancelFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/CancelFrame.kt
@@ -19,8 +19,9 @@ package io.rsocket.kotlin.frame
 import io.ktor.utils.io.core.*
 
 internal class CancelFrame(
-    override val streamId: Int,
-) : Frame(FrameType.Cancel) {
+    override val streamId: Int
+) : Frame() {
+    override val type: FrameType get() = FrameType.Cancel
     override val flags: Int get() = 0
 
     override fun release(): Unit = Unit

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
@@ -22,7 +22,8 @@ import io.rsocket.kotlin.*
 internal class ErrorFrame(
     override val streamId: Int,
     val throwable: Throwable
-) : Frame(FrameType.Error) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.Error
     override val flags: Int get() = 0
     val errorCode get() = (throwable as? RSocketError)?.errorCode ?: ErrorCode.ApplicationError
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
@@ -17,6 +17,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.payload.*
 
@@ -47,7 +49,7 @@ internal class ExtensionFrame(
     }
 }
 
-internal fun ByteReadPacket.readExtension(pool: BufferPool, streamId: Int, flags: Int): ExtensionFrame {
+internal fun ByteReadPacket.readExtension(pool: ObjectPool<ChunkBuffer>, streamId: Int, flags: Int): ExtensionFrame {
     val extendedType = readInt()
     val payload = readPayload(pool, flags)
     return ExtensionFrame(streamId, extendedType, payload)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
@@ -24,7 +24,8 @@ internal class ExtensionFrame(
     override val streamId: Int,
     val extendedType: Int,
     val payload: Payload,
-) : Frame(FrameType.Extension) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.Extension
     override val flags: Int get() = if (payload.metadata != null) Flags.Metadata else 0
 
     override fun release() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
@@ -24,18 +24,18 @@ import io.rsocket.kotlin.frame.io.*
 private const val FlagsMask: Int = 1023
 private const val FrameTypeShift: Int = 10
 
-sealed class Frame(open val type: FrameType) : Closeable {
-    abstract val streamId: Int
-    abstract val flags: Int
+public sealed class Frame(public open val type: FrameType) : Closeable {
+    public abstract val streamId: Int
+    public abstract val flags: Int
 
-    abstract fun release()
+    internal abstract fun release()
 
     protected abstract fun BytePacketBuilder.writeSelf()
     protected abstract fun StringBuilder.appendFlags()
     protected abstract fun StringBuilder.appendSelf()
 
     @DangerousInternalIoApi
-    fun toPacket(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
+    internal fun toPacket(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
         check(type.canHaveMetadata || !(flags check Flags.Metadata)) { "bad value for metadata flag" }
         return buildPacket(pool) {
             writeInt(streamId)
@@ -61,7 +61,7 @@ sealed class Frame(open val type: FrameType) : Closeable {
 }
 
 @DangerousInternalIoApi
-fun ByteReadPacket.readFrame(pool: ObjectPool<ChunkBuffer>): Frame = use {
+internal fun ByteReadPacket.readFrame(pool: ObjectPool<ChunkBuffer>): Frame = use {
     val streamId = readInt()
     val typeAndFlags = readShort().toInt() and 0xFFFF
     val flags = typeAndFlags and FlagsMask

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
@@ -24,7 +24,8 @@ import io.rsocket.kotlin.frame.io.*
 private const val FlagsMask: Int = 1023
 private const val FrameTypeShift: Int = 10
 
-public sealed class Frame(public open val type: FrameType) : Closeable {
+public sealed class Frame : Closeable {
+    public abstract val type: FrameType
     public abstract val streamId: Int
     public abstract val flags: Int
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
@@ -35,7 +35,6 @@ public sealed class Frame : Closeable {
     protected abstract fun StringBuilder.appendFlags()
     protected abstract fun StringBuilder.appendSelf()
 
-    @DangerousInternalIoApi
     internal fun toPacket(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
         check(type.canHaveMetadata || !(flags check Flags.Metadata)) { "bad value for metadata flag" }
         return buildPacket(pool) {
@@ -61,7 +60,6 @@ public sealed class Frame : Closeable {
     }
 }
 
-@DangerousInternalIoApi
 internal fun ByteReadPacket.readFrame(pool: ObjectPool<ChunkBuffer>): Frame = use {
     val streamId = readInt()
     val typeAndFlags = readShort().toInt() and 0xFFFF

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/FrameType.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/FrameType.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.rsocket.kotlin.frame.io.*
 
-internal enum class FrameType(val encodedType: Int, flags: Int = Flags.Empty) {
+public enum class FrameType(public val encodedType: Int, flags: Int = Flags.Empty) {
     Reserved(0x00),
 
     //CONNECTION
@@ -49,11 +49,11 @@ internal enum class FrameType(val encodedType: Int, flags: Int = Flags.Empty) {
 
     Extension(0x3F, Flags.CanHaveData or Flags.CanHaveMetadata);
 
-    val hasInitialRequest: Boolean = flags check Flags.HasInitialRequest
-    val isRequestType: Boolean = flags check Flags.Request
-    val isFragmentable: Boolean = flags check Flags.Fragmentable
-    val canHaveMetadata: Boolean = flags check Flags.CanHaveMetadata
-    val canHaveData: Boolean = flags check Flags.CanHaveData
+    public val hasInitialRequest: Boolean = flags check Flags.HasInitialRequest
+    public val isRequestType: Boolean = flags check Flags.Request
+    public val isFragmentable: Boolean = flags check Flags.Fragmentable
+    public val canHaveMetadata: Boolean = flags check Flags.CanHaveMetadata
+    public val canHaveData: Boolean = flags check Flags.CanHaveData
 
     private object Flags {
         const val Empty = 0
@@ -64,7 +64,7 @@ internal enum class FrameType(val encodedType: Int, flags: Int = Flags.Empty) {
         const val CanHaveData = 16
     }
 
-    companion object {
+    internal companion object {
         private val encodedTypes: Array<FrameType?>
 
         init {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
@@ -25,7 +25,8 @@ internal class KeepAliveFrame(
     val respond: Boolean,
     val lastPosition: Long,
     val data: ByteReadPacket,
-) : Frame(FrameType.KeepAlive) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.KeepAlive
     override val streamId: Int get() = 0
     override val flags: Int get() = if (respond) RespondFlag else 0
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
@@ -17,6 +17,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 
 private const val RespondFlag = 128
@@ -49,7 +51,7 @@ internal class KeepAliveFrame(
     }
 }
 
-internal fun ByteReadPacket.readKeepAlive(pool: BufferPool, flags: Int): KeepAliveFrame {
+internal fun ByteReadPacket.readKeepAlive(pool: ObjectPool<ChunkBuffer>, flags: Int): KeepAliveFrame {
     val respond = flags check RespondFlag
     val lastPosition = readLong()
     val data = readPacket(pool)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
@@ -23,7 +23,8 @@ internal class LeaseFrame(
     val ttl: Int,
     val numberOfRequests: Int,
     val metadata: ByteReadPacket?,
-) : Frame(FrameType.Lease) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.Lease
     override val streamId: Int get() = 0
     override val flags: Int get() = if (metadata != null) Flags.Metadata else 0
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
@@ -17,6 +17,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 
 internal class LeaseFrame(
@@ -48,7 +50,7 @@ internal class LeaseFrame(
     }
 }
 
-internal fun ByteReadPacket.readLease(pool: BufferPool, flags: Int): LeaseFrame {
+internal fun ByteReadPacket.readLease(pool: ObjectPool<ChunkBuffer>, flags: Int): LeaseFrame {
     val ttl = readInt()
     val numberOfRequests = readInt()
     val metadata = if (flags check Flags.Metadata) readMetadata(pool) else null

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
@@ -21,7 +21,8 @@ import io.rsocket.kotlin.frame.io.*
 
 internal class MetadataPushFrame(
     val metadata: ByteReadPacket,
-) : Frame(FrameType.MetadataPush) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.MetadataPush
     override val streamId: Int get() = 0
     override val flags: Int get() = Flags.Metadata
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
@@ -17,6 +17,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 
 internal class MetadataPushFrame(
@@ -43,4 +45,4 @@ internal class MetadataPushFrame(
     }
 }
 
-internal fun ByteReadPacket.readMetadataPush(pool: BufferPool): MetadataPushFrame = MetadataPushFrame(readPacket(pool))
+internal fun ByteReadPacket.readMetadataPush(pool: ObjectPool<ChunkBuffer>): MetadataPushFrame = MetadataPushFrame(readPacket(pool))

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
@@ -19,6 +19,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.payload.*
 
@@ -63,7 +65,13 @@ internal class RequestFrame(
     }
 }
 
-internal fun ByteReadPacket.readRequest(pool: BufferPool, type: FrameType, streamId: Int, flags: Int, withInitial: Boolean): RequestFrame {
+internal fun ByteReadPacket.readRequest(
+    pool: ObjectPool<ChunkBuffer>,
+    type: FrameType,
+    streamId: Int,
+    flags: Int,
+    withInitial: Boolean
+): RequestFrame {
     val fragmentFollows = flags check Flags.Follows
     val complete = flags check Flags.Complete
     val next = flags check Flags.Next

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
@@ -30,7 +30,7 @@ internal class RequestFrame(
     val next: Boolean,
     val initialRequest: Int,
     val payload: Payload,
-) : Frame(type) {
+) : Frame() {
     override val flags: Int
         get() {
             var flags = 0

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
@@ -21,7 +21,8 @@ import io.ktor.utils.io.core.*
 internal class RequestNFrame(
     override val streamId: Int,
     val requestN: Int,
-) : Frame(FrameType.RequestN) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.RequestN
     override val flags: Int get() = 0
 
     override fun release(): Unit = Unit

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
@@ -24,7 +24,8 @@ internal class ResumeFrame(
     val resumeToken: ByteReadPacket,
     val lastReceivedServerPosition: Long,
     val firstAvailableClientPosition: Long,
-) : Frame(FrameType.Resume) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.Resume
     override val streamId: Int get() = 0
     override val flags: Int get() = 0
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
@@ -17,6 +17,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 
 internal class ResumeFrame(
@@ -48,7 +50,7 @@ internal class ResumeFrame(
     }
 }
 
-internal fun ByteReadPacket.readResume(pool: BufferPool): ResumeFrame {
+internal fun ByteReadPacket.readResume(pool: ObjectPool<ChunkBuffer>): ResumeFrame {
     val version = readVersion()
     val resumeToken = readResumeToken(pool)
     val lastReceivedServerPosition = readLong()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
@@ -20,7 +20,8 @@ import io.ktor.utils.io.core.*
 
 internal class ResumeOkFrame(
     val lastReceivedClientPosition: Long,
-) : Frame(FrameType.ResumeOk) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.ResumeOk
     override val streamId: Int get() = 0
     override val flags: Int get() = 0
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
@@ -31,7 +31,8 @@ internal class SetupFrame(
     val resumeToken: ByteReadPacket?,
     val payloadMimeType: PayloadMimeType,
     val payload: Payload,
-) : Frame(FrameType.Setup) {
+) : Frame() {
+    override val type: FrameType get() = FrameType.Setup
     override val streamId: Int get() = 0
     override val flags: Int
         get() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
@@ -17,6 +17,8 @@
 package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.payload.*
@@ -74,7 +76,7 @@ internal class SetupFrame(
     }
 }
 
-internal fun ByteReadPacket.readSetup(pool: BufferPool, flags: Int): SetupFrame {
+internal fun ByteReadPacket.readSetup(pool: ObjectPool<ChunkBuffer>, flags: Int): SetupFrame {
     val version = readVersion()
     val keepAlive = run {
         val interval = readInt()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/length.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/length.kt
@@ -20,14 +20,14 @@ import io.ktor.utils.io.core.*
 
 private const val lengthMask: Int = 0xFFFFFF.inv()
 
-fun ByteReadPacket.readLength(): Int {
+internal fun ByteReadPacket.readLength(): Int {
     val b = readByte().toInt() and 0xFF shl 16
     val b1 = readByte().toInt() and 0xFF shl 8
     val b2 = readByte().toInt() and 0xFF
     return b or b1 or b2
 }
 
-fun BytePacketBuilder.writeLength(length: Int) {
+internal fun BytePacketBuilder.writeLength(length: Int) {
     require(length and lengthMask == 0) { "Length is larger than 24 bits" }
     writeByte((length shr 16).toByte())
     writeByte((length shr 8).toByte())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/mimeType.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/mimeType.kt
@@ -25,7 +25,6 @@ internal fun BytePacketBuilder.writeMimeType(type: MimeType) {
     when (type) {
         is MimeTypeWithId   -> writeIdentifier(type.identifier)
         is MimeTypeWithName -> writeTextWithLength(type.text)
-        else                -> error("Unknown mime type")
     }
 }
 
@@ -38,7 +37,6 @@ internal fun BytePacketBuilder.writeAuthType(type: AuthType) {
     when (type) {
         is AuthTypeWithId   -> writeIdentifier(type.identifier)
         is AuthTypeWithName -> writeTextWithLength(type.text)
-        else                -> error("Unknown mime type")
     }
 }
 
@@ -74,5 +72,5 @@ private inline fun <T> ByteReadPacket.readType(
 }
 
 internal fun String.requireAscii() {
-    require(all { it.toInt() <= 0x7f }) { "String should be an ASCII encodded string" }
+    require(all { it.code <= 0x7f }) { "String should be an ASCII encodded string" }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/packet.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/packet.kt
@@ -20,10 +20,7 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 
-@OptIn(DangerousInternalIoApi::class)
-internal typealias BufferPool = ObjectPool<ChunkBuffer>
-
-internal inline fun buildPacket(pool: BufferPool, block: BytePacketBuilder.() -> Unit): ByteReadPacket {
+internal inline fun buildPacket(pool: ObjectPool<ChunkBuffer>, block: BytePacketBuilder.() -> Unit): ByteReadPacket {
     val builder = BytePacketBuilder(0, pool)
     try {
         block(builder)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
@@ -17,9 +17,11 @@
 package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.payload.*
 
-internal fun ByteReadPacket.readMetadata(pool: BufferPool): ByteReadPacket {
+internal fun ByteReadPacket.readMetadata(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
     val length = readLength()
     return readPacket(pool, length)
 }
@@ -31,7 +33,7 @@ internal fun BytePacketBuilder.writeMetadata(metadata: ByteReadPacket?) {
     }
 }
 
-internal fun ByteReadPacket.readPayload(pool: BufferPool, flags: Int): Payload {
+internal fun ByteReadPacket.readPayload(pool: ObjectPool<ChunkBuffer>, flags: Int): Payload {
     val metadata = if (flags check Flags.Metadata) readMetadata(pool) else null
     val data = readPacket(pool)
     return Payload(data = data, metadata = metadata)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
@@ -17,8 +17,10 @@
 package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 
-internal fun ByteReadPacket.readResumeToken(pool: BufferPool): ByteReadPacket {
+internal fun ByteReadPacket.readResumeToken(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
     val length = readShort().toInt() and 0xFFFF
     return readPacket(pool, length)
 }
@@ -31,14 +33,14 @@ internal fun BytePacketBuilder.writeResumeToken(resumeToken: ByteReadPacket?) {
     }
 }
 
-internal fun ByteReadPacket.readPacket(pool: BufferPool): ByteReadPacket {
+internal fun ByteReadPacket.readPacket(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
     if (isEmpty) return ByteReadPacket.Empty
     return buildPacket(pool) {
         writePacket(this@readPacket)
     }
 }
 
-internal fun ByteReadPacket.readPacket(pool: BufferPool, length: Int): ByteReadPacket {
+internal fun ByteReadPacket.readPacket(pool: ObjectPool<ChunkBuffer>, length: Int): ByteReadPacket {
     if (length == 0) return ByteReadPacket.Empty
     return buildPacket(pool) {
         writePacket(this@readPacket, length)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
@@ -17,9 +17,6 @@
 package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
-import io.rsocket.kotlin.keepalive.*
-import io.rsocket.kotlin.payload.*
-import kotlin.time.*
 
 internal fun ByteReadPacket.readResumeToken(pool: BufferPool): ByteReadPacket {
     val length = readShort().toInt() and 0xFFFF

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.core
+package io.rsocket.kotlin.internal
 
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.internal.*
+import io.rsocket.kotlin.core.*
 
 @OptIn(TransportApi::class)
 internal suspend inline fun Connection.connect(

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/KeepAliveHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/KeepAliveHandler.kt
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.keepalive
+package io.rsocket.kotlin.internal
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.keepalive.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
@@ -16,7 +16,7 @@
 
 @file:OptIn(TransportApi::class)
 
-package io.rsocket.kotlin.core
+package io.rsocket.kotlin.internal
 
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(TransportApi::class)
+@file:OptIn(TransportApi::class, RSocketLoggingApi::class)
 
 package io.rsocket.kotlin.internal
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
@@ -19,7 +19,6 @@
 package io.rsocket.kotlin.internal
 
 import io.ktor.utils.io.core.*
-import io.ktor.utils.io.core.internal.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.logging.*
@@ -27,7 +26,6 @@ import io.rsocket.kotlin.logging.*
 internal fun Connection.logging(logger: Logger): Connection =
     if (logger.isLoggable(LoggingLevel.DEBUG)) LoggingConnection(this, logger) else this
 
-@OptIn(DangerousInternalIoApi::class)
 private class LoggingConnection(
     private val delegate: Connection,
     private val logger: Logger,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketState.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketState.kt
@@ -120,10 +120,7 @@ internal class RSocketState(
     private fun handleFrame(responder: RSocketResponder, frame: Frame) {
         when (val streamId = frame.streamId) {
             0    -> when (frame) {
-                is ErrorFrame        -> {
-                    job.cancel("Error frame received on 0 stream", frame.throwable)
-                    frame.release() //TODO
-                }
+                is ErrorFrame        -> job.cancel("Error frame received on 0 stream", frame.throwable)
                 is KeepAliveFrame    -> keepAliveHandler.receive(frame)
                 is LeaseFrame        -> {
                     frame.release()
@@ -139,10 +136,7 @@ internal class RSocketState(
             else -> when (frame) {
                 is RequestNFrame -> limits[streamId]?.updateRequests(frame.requestN)
                 is CancelFrame   -> senders.remove(streamId)?.cancel()
-                is ErrorFrame    -> {
-                    receivers.remove(streamId)?.close(frame.throwable)
-                    frame.release()
-                }
+                is ErrorFrame    -> receivers.remove(streamId)?.close(frame.throwable)
                 is RequestFrame  -> when (frame.type) {
                     FrameType.Payload         -> receivers[streamId]?.safeOffer(frame) ?: frame.release()
                     FrameType.RequestFnF      -> responder.handleFireAndForget(frame)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/ReconnectableRSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/ReconnectableRSocket.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.*
 
 internal typealias ReconnectPredicate = suspend (cause: Throwable, attempt: Long) -> Boolean
 
+@OptIn(RSocketLoggingApi::class)
 @Suppress("FunctionName")
 internal suspend fun ReconnectableRSocket(
     logger: Logger,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/ReconnectableRSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/ReconnectableRSocket.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.core
+package io.rsocket.kotlin.internal
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/flow/LimitingFlowCollector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/flow/LimitingFlowCollector.kt
@@ -39,12 +39,7 @@ internal class LimitingFlowCollector(
     }
 
     override suspend fun emit(value: Payload): Unit = value.closeOnError {
-        try {
-            useRequest()
-        } catch (t: Throwable) {
-            value.release()
-            throw t
-        }
+        useRequest()
         state.send(NextPayloadFrame(streamId, value))
     }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/logging/Logging.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/logging/Logging.kt
@@ -16,21 +16,28 @@
 
 package io.rsocket.kotlin.logging
 
-enum class LoggingLevel { TRACE, DEBUG, INFO, WARN, ERROR }
+import io.rsocket.kotlin.*
 
-fun interface LoggerFactory {
-    fun logger(tag: String): Logger
+@RSocketLoggingApi
+public enum class LoggingLevel { TRACE, DEBUG, INFO, WARN, ERROR }
+
+@RSocketLoggingApi
+public fun interface LoggerFactory {
+    public fun logger(tag: String): Logger
 }
 
-expect val DefaultLoggerFactory: LoggerFactory
+@RSocketLoggingApi
+internal expect val DefaultLoggerFactory: LoggerFactory
 
-interface Logger {
-    val tag: String
-    fun isLoggable(level: LoggingLevel): Boolean
-    fun rawLog(level: LoggingLevel, throwable: Throwable?, message: Any?)
+@RSocketLoggingApi
+public interface Logger {
+    public val tag: String
+    public fun isLoggable(level: LoggingLevel): Boolean
+    public fun rawLog(level: LoggingLevel, throwable: Throwable?, message: Any?)
 }
 
-inline fun Logger.log(level: LoggingLevel, throwable: Throwable? = null, message: () -> Any?) {
+@RSocketLoggingApi
+public inline fun Logger.log(level: LoggingLevel, throwable: Throwable? = null, message: () -> Any?) {
     if (!isLoggable(level)) return
 
     val msg = try {
@@ -41,22 +48,27 @@ inline fun Logger.log(level: LoggingLevel, throwable: Throwable? = null, message
     rawLog(level, throwable, msg)
 }
 
-inline fun Logger.trace(throwable: Throwable? = null, message: () -> Any?) {
+@RSocketLoggingApi
+public inline fun Logger.trace(throwable: Throwable? = null, message: () -> Any?) {
     log(LoggingLevel.TRACE, throwable, message)
 }
 
-inline fun Logger.debug(throwable: Throwable? = null, message: () -> Any?) {
+@RSocketLoggingApi
+public inline fun Logger.debug(throwable: Throwable? = null, message: () -> Any?) {
     log(LoggingLevel.DEBUG, throwable, message)
 }
 
-inline fun Logger.info(throwable: Throwable? = null, message: () -> Any?) {
+@RSocketLoggingApi
+public inline fun Logger.info(throwable: Throwable? = null, message: () -> Any?) {
     log(LoggingLevel.INFO, throwable, message)
 }
 
-inline fun Logger.warn(throwable: Throwable? = null, message: () -> Any?) {
+@RSocketLoggingApi
+public inline fun Logger.warn(throwable: Throwable? = null, message: () -> Any?) {
     log(LoggingLevel.WARN, throwable, message)
 }
 
-inline fun Logger.error(throwable: Throwable? = null, message: () -> Any?) {
+@RSocketLoggingApi
+public inline fun Logger.error(throwable: Throwable? = null, message: () -> Any?) {
     log(LoggingLevel.ERROR, throwable, message)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/logging/NoopLogger.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/logging/NoopLogger.kt
@@ -16,10 +16,13 @@
 
 package io.rsocket.kotlin.logging
 
+import io.rsocket.kotlin.*
+
 /**
  * Logger implementation, that never print
  */
-object NoopLogger : Logger, LoggerFactory {
+@RSocketLoggingApi
+public object NoopLogger : Logger, LoggerFactory {
     override val tag: String get() = "noop"
     override fun isLoggable(level: LoggingLevel): Boolean = false
     override fun rawLog(level: LoggingLevel, throwable: Throwable?, message: Any?): Unit = Unit

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/logging/PrintLogger.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/logging/PrintLogger.kt
@@ -16,7 +16,10 @@
 
 package io.rsocket.kotlin.logging
 
-class PrintLogger(
+import io.rsocket.kotlin.*
+
+@RSocketLoggingApi
+public class PrintLogger(
     override val tag: String,
     private val minLevel: LoggingLevel = LoggingLevel.INFO,
 ) : Logger {
@@ -26,9 +29,9 @@ class PrintLogger(
         println("[$level] ($tag) $message $error")
     }
 
-    companion object : LoggerFactory {
+    public companion object : LoggerFactory {
         override fun logger(tag: String): Logger = PrintLogger(tag)
 
-        fun withLevel(minLevel: LoggingLevel): LoggerFactory = LoggerFactory { PrintLogger(it, minLevel) }
+        public fun withLevel(minLevel: LoggingLevel): LoggerFactory = LoggerFactory { PrintLogger(it, minLevel) }
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
@@ -50,8 +50,6 @@ public interface CompositeMetadata : Metadata {
 
     public companion object Reader : MetadataReader<CompositeMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketCompositeMetadata
-
-        @DangerousInternalIoApi
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): CompositeMetadata {
             val list = mutableListOf<Entry>()
             while (isNotEmpty) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
@@ -26,26 +26,19 @@ import io.rsocket.kotlin.core.*
 public fun CompositeMetadata.Entry.hasMimeTypeOf(reader: MetadataReader<*>): Boolean = mimeType == reader.mimeType
 
 @ExperimentalMetadataApi
-@OptIn(DangerousInternalIoApi::class)
-public fun <M : Metadata> CompositeMetadata.Entry.read(reader: MetadataReader<M>): M = read(ChunkBuffer.Pool, reader)
-
-@ExperimentalMetadataApi
-@OptIn(DangerousInternalIoApi::class)
-public fun <M : Metadata> CompositeMetadata.Entry.readOrNull(reader: MetadataReader<M>): M? = readOrNull(ChunkBuffer.Pool, reader)
-
-@ExperimentalMetadataApi
-@DangerousInternalIoApi
-public fun <M : Metadata> CompositeMetadata.Entry.read(pool: ObjectPool<ChunkBuffer>, reader: MetadataReader<M>): M {
-    if (mimeType == reader.mimeType) return content.read(pool, reader)
+public fun <M : Metadata> CompositeMetadata.Entry.read(reader: MetadataReader<M>, pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool): M {
+    if (mimeType == reader.mimeType) return content.read(reader, pool)
 
     content.release()
     error("Expected mimeType '${reader.mimeType}' but was '$mimeType'")
 }
 
 @ExperimentalMetadataApi
-@DangerousInternalIoApi
-public fun <M : Metadata> CompositeMetadata.Entry.readOrNull(pool: ObjectPool<ChunkBuffer>, reader: MetadataReader<M>): M? {
-    return if (mimeType == reader.mimeType) content.read(pool, reader) else null
+public fun <M : Metadata> CompositeMetadata.Entry.readOrNull(
+    reader: MetadataReader<M>,
+    pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool
+): M? {
+    return if (mimeType == reader.mimeType) content.read(reader, pool) else null
 }
 
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
@@ -33,8 +33,6 @@ public interface Metadata {
 @ExperimentalMetadataApi
 public interface MetadataReader<M : Metadata> {
     public val mimeType: MimeType
-
-    @DangerousInternalIoApi
     public fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): M
 }
 
@@ -43,19 +41,9 @@ public interface MetadataReader<M : Metadata> {
 public fun PayloadBuilder.metadata(metadata: Metadata): Unit = metadata(metadata.toPacket())
 
 @ExperimentalMetadataApi
-@OptIn(DangerousInternalIoApi::class)
-public fun <M : Metadata> ByteReadPacket.read(reader: MetadataReader<M>): M = read(ChunkBuffer.Pool, reader)
-
-@ExperimentalMetadataApi
-public fun Metadata.toPacket(): ByteReadPacket = buildPacket { writeSelf() }
-
-
-@ExperimentalMetadataApi
-@DangerousInternalIoApi
-public fun <M : Metadata> ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>, reader: MetadataReader<M>): M = use {
+public fun <M : Metadata> ByteReadPacket.read(reader: MetadataReader<M>, pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool): M = use {
     with(reader) { read(pool) }
 }
 
 @ExperimentalMetadataApi
-@DangerousInternalIoApi
-public fun Metadata.toPacket(pool: ObjectPool<ChunkBuffer>): ByteReadPacket = buildPacket(pool) { writeSelf() }
+public fun Metadata.toPacket(pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool): ByteReadPacket = buildPacket(pool) { writeSelf() }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
@@ -39,8 +39,6 @@ public class PerStreamAcceptableDataMimeTypesMetadata(public val types: List<Mim
 
     public companion object Reader : MetadataReader<PerStreamAcceptableDataMimeTypesMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAcceptMimeTypes
-
-        @DangerousInternalIoApi
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): PerStreamAcceptableDataMimeTypesMetadata {
             val list = mutableListOf<MimeType>()
             while (isNotEmpty) list.add(readMimeType())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
@@ -33,8 +33,6 @@ public class PerStreamDataMimeTypeMetadata(public val type: MimeType) : Metadata
 
     public companion object Reader : MetadataReader<PerStreamDataMimeTypeMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketMimeType
-
-        @DangerousInternalIoApi
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): PerStreamDataMimeTypeMetadata =
             PerStreamDataMimeTypeMetadata(readMimeType())
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
@@ -33,7 +33,6 @@ public class RawMetadata(
     }
 
     private class Reader(override val mimeType: MimeType) : MetadataReader<RawMetadata> {
-        @DangerousInternalIoApi
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): RawMetadata = RawMetadata(mimeType, readPacket(pool))
     }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
@@ -45,8 +45,6 @@ public class RoutingMetadata(public val tags: List<String>) : Metadata {
 
     public companion object Reader : MetadataReader<RoutingMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketRouting
-
-        @DangerousInternalIoApi
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): RoutingMetadata {
             val list = mutableListOf<String>()
             while (isNotEmpty) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
@@ -69,8 +69,6 @@ public class ZipkinTracingMetadata internal constructor(
 
     public companion object Reader : MetadataReader<ZipkinTracingMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketTracingZipkin
-
-        @DangerousInternalIoApi
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): ZipkinTracingMetadata {
             val flags = readByte()
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
@@ -39,12 +39,9 @@ public interface AuthMetadata : Metadata {
 
 @ExperimentalMetadataApi
 public interface AuthMetadataReader<AM : AuthMetadata> : MetadataReader<AM> {
-    @DangerousInternalIoApi
     public fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): AM
 
     override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAuthentication
-
-    @DangerousInternalIoApi
     override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): AM {
         val type = readAuthType()
         return readContent(type, pool)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthType.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthType.kt
@@ -18,13 +18,13 @@ package io.rsocket.kotlin.metadata.security
 
 import io.rsocket.kotlin.frame.io.*
 
-public interface AuthType
+public sealed interface AuthType
 
-public interface AuthTypeWithName : AuthType {
+public sealed interface AuthTypeWithName : AuthType {
     public val text: String
 }
 
-public interface AuthTypeWithId : AuthType {
+public sealed interface AuthTypeWithId : AuthType {
     public val identifier: Byte
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
@@ -31,7 +31,6 @@ public class BearerAuthMetadata(
     }
 
     public companion object Reader : AuthMetadataReader<BearerAuthMetadata> {
-        @DangerousInternalIoApi
         override fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): BearerAuthMetadata {
             require(type == WellKnowAuthType.Bearer) { "Metadata auth type should be 'bearer'" }
             val token = readText()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
@@ -33,7 +33,6 @@ public class RawAuthMetadata(
     }
 
     public companion object Reader : AuthMetadataReader<RawAuthMetadata> {
-        @DangerousInternalIoApi
         override fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): RawAuthMetadata {
             val content = readPacket(pool)
             return RawAuthMetadata(type, content)
@@ -45,26 +44,19 @@ public class RawAuthMetadata(
 public fun RawAuthMetadata.hasAuthTypeOf(reader: AuthMetadataReader<*>): Boolean = type == reader.mimeType
 
 @ExperimentalMetadataApi
-@OptIn(DangerousInternalIoApi::class)
-public fun <AM : AuthMetadata> RawAuthMetadata.read(reader: AuthMetadataReader<AM>): AM = read(ChunkBuffer.Pool, reader)
-
-@ExperimentalMetadataApi
-@OptIn(DangerousInternalIoApi::class)
-public fun <AM : AuthMetadata> RawAuthMetadata.readOrNull(reader: AuthMetadataReader<AM>): AM? = readOrNull(ChunkBuffer.Pool, reader)
-
-
-@ExperimentalMetadataApi
-@DangerousInternalIoApi
-public fun <AM : AuthMetadata> RawAuthMetadata.read(pool: ObjectPool<ChunkBuffer>, reader: AuthMetadataReader<AM>): AM {
-    return readOrNull(pool, reader) ?: run {
+public fun <AM : AuthMetadata> RawAuthMetadata.read(reader: AuthMetadataReader<AM>, pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool): AM {
+    return readOrNull(reader, pool) ?: run {
         content.release()
         error("Expected auth type '${reader.mimeType}' but was '$mimeType'")
     }
 }
 
 @ExperimentalMetadataApi
-@DangerousInternalIoApi
-public fun <AM : AuthMetadata> RawAuthMetadata.readOrNull(pool: ObjectPool<ChunkBuffer>, reader: AuthMetadataReader<AM>): AM? {
+
+public fun <AM : AuthMetadata> RawAuthMetadata.readOrNull(
+    reader: AuthMetadataReader<AM>,
+    pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool
+): AM? {
     if (type != reader.mimeType) return null
 
     with(reader) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
@@ -40,7 +40,6 @@ public class SimpleAuthMetadata(
     }
 
     public companion object Reader : AuthMetadataReader<SimpleAuthMetadata> {
-        @DangerousInternalIoApi
         override fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): SimpleAuthMetadata {
             require(type == WellKnowAuthType.Simple) { "Metadata auth type should be 'simple'" }
             val length = readShort().toInt()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/Payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/Payload.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 
 public fun Payload(data: ByteReadPacket, metadata: ByteReadPacket? = null): Payload = DefaultPayload(data, metadata)
 
-public interface Payload : Closeable {
+public sealed interface Payload : Closeable {
     public val data: ByteReadPacket
     public val metadata: ByteReadPacket?
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/PayloadBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/PayloadBuilder.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.payload
 
 import io.ktor.utils.io.core.*
 
-public interface PayloadBuilder {
+public sealed interface PayloadBuilder {
     public fun data(value: ByteReadPacket)
     public fun metadata(value: ByteReadPacket)
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ClientTransport.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ClientTransport.kt
@@ -18,14 +18,7 @@ package io.rsocket.kotlin.transport
 
 import io.rsocket.kotlin.*
 
-//TODO fun interfaces don't support `suspend` functions for now... (seems will work in kotlin 1.5)
-
-public /*fun*/ interface ClientTransport {
+public fun interface ClientTransport {
     @TransportApi
     public suspend fun connect(): Connection
-}
-
-@TransportApi
-public inline fun ClientTransport(crossinline block: suspend () -> Connection): ClientTransport = object : ClientTransport {
-    override suspend fun connect(): Connection = block()
 }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/RSocketCustomErrorTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/RSocketCustomErrorTest.kt
@@ -1,8 +1,6 @@
 package io.rsocket.kotlin
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import kotlin.test.*
 
 class RSocketCustomErrorTest {
 

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/SetupRejectionTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/SetupRejectionTest.kt
@@ -52,7 +52,6 @@ class SetupRejectionTest : SuspendTest, TestWithLeakCheck {
                 assertTrue(frame is ErrorFrame)
                 assertTrue(frame.throwable is RSocketError.Setup.Rejected)
                 assertEquals(errorMessage, frame.throwable.message)
-                assertEquals(errorMessage, frame.data?.readText())
             }
             val sender = sendingRSocket.await()
             assertFalse(sender.job.isActive)

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/RSocketTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/RSocketTest.kt
@@ -61,7 +61,7 @@ class RSocketTest : SuspendTest, TestWithLeakCheck {
         return RSocketConnector {
             loggerFactory = NoopLogger
             connectionConfig {
-                keepAlive = KeepAlive(1000.seconds, 1000.seconds)
+                keepAlive = KeepAlive(Duration.seconds(1000), Duration.seconds(1000))
             }
         }.connect(localServer)
     }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/ReconnectableRSocketTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/ReconnectableRSocketTest.kt
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.core
 import app.cash.turbine.*
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.test.*

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/ErrorFrameTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/ErrorFrameTest.kt
@@ -44,7 +44,6 @@ class ErrorFrameTest : TestWithLeakCheck {
         assertEquals(ErrorCode.ApplicationError, frame.errorCode)
         assertTrue(frame.throwable is RSocketError.ApplicationError)
         assertEquals("d", frame.throwable.message)
-        assertEquals("d", frame.data?.readText())
     }
 
 }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/SetupFrameTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/SetupFrameTest.kt
@@ -28,7 +28,7 @@ import kotlin.time.*
 class SetupFrameTest : TestWithLeakCheck {
 
     private val version = Version.Current
-    private val keepAlive = KeepAlive(10.seconds, 500.seconds)
+    private val keepAlive = KeepAlive(Duration.seconds(10), Duration.seconds(500))
     private val payloadMimeType = PayloadMimeType(WellKnownMimeType.ApplicationOctetStream, CustomMimeType("mime"))
 
     @Test

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/RSocketRequesterTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/RSocketRequesterTest.kt
@@ -33,7 +33,7 @@ class RSocketRequesterTest : TestWithConnection(), TestWithLeakCheck {
     override suspend fun before() {
         super.before()
 
-        val state = RSocketState(connection, KeepAlive(1000.seconds, 1000.seconds))
+        val state = RSocketState(connection, KeepAlive(Duration.seconds(1000), Duration.seconds(1000)))
         requester = RSocketRequester(state, StreamId.client())
         state.start(RSocketRequestHandler { })
     }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
@@ -27,7 +27,7 @@ import kotlin.time.*
 
 class KeepAliveTest : TestWithConnection(), TestWithLeakCheck {
 
-    private fun requester(keepAlive: KeepAlive = KeepAlive(100.milliseconds, 1.seconds)): RSocket = run {
+    private fun requester(keepAlive: KeepAlive = KeepAlive(Duration.milliseconds(100), Duration.seconds(1))): RSocket = run {
         val state = RSocketState(connection, keepAlive)
         val requester = RSocketRequester(state, StreamId.client())
         state.start(RSocketRequestHandler { })
@@ -49,10 +49,10 @@ class KeepAliveTest : TestWithConnection(), TestWithLeakCheck {
 
     @Test
     fun rSocketNotCanceledOnPresentKeepAliveTicks() = test {
-        val rSocket = requester(KeepAlive(100.seconds, 100.seconds))
+        val rSocket = requester(KeepAlive(Duration.seconds(100), Duration.seconds(100)))
         connection.launch {
             repeat(50) {
-                delay(100.milliseconds)
+                delay(Duration.milliseconds(100))
                 connection.sendToReceiver(KeepAliveFrame(true, 0, ByteReadPacket.Empty))
             }
         }
@@ -67,10 +67,10 @@ class KeepAliveTest : TestWithConnection(), TestWithLeakCheck {
 
     @Test
     fun requesterRespondsToKeepAlive() = test {
-        requester(KeepAlive(100.seconds, 100.seconds))
+        requester(KeepAlive(Duration.seconds(100), Duration.seconds(100)))
         connection.launch {
             while (isActive) {
-                delay(100.milliseconds)
+                delay(Duration.milliseconds(100))
                 connection.sendToReceiver(KeepAliveFrame(true, 0, ByteReadPacket.Empty))
             }
         }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
@@ -56,7 +56,7 @@ class KeepAliveTest : TestWithConnection(), TestWithLeakCheck {
                 connection.sendToReceiver(KeepAliveFrame(true, 0, ByteReadPacket.Empty))
             }
         }
-        delay(1.5.seconds)
+        delay(Duration.seconds(1.5))
         assertTrue(rSocket.job.isActive)
         connection.test {
             repeat(50) {

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataTest.kt
@@ -29,7 +29,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(CustomMimeType("w"), ByteReadPacket.Empty)
         }
 
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
 
         assertEquals(1, decoded.entries.size)
         val entry = decoded.entries.first()
@@ -44,7 +44,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(ReservedMimeType(120), packet("reserved metadata"))
             add(WellKnownMimeType.ApplicationAvro, packet("avro metadata"))
         }
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
 
         assertEquals(3, decoded.entries.size)
         decoded.entries[0].let { custom ->
@@ -67,7 +67,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             writeByte(120)
         }
         assertFails {
-            packet.read(InUseTrackingPool, CompositeMetadata)
+            packet.read(CompositeMetadata, InUseTrackingPool)
         }
     }
 
@@ -78,7 +78,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(ReservedMimeType(120), packet("reserved metadata"))
             add(WellKnownMimeType.ApplicationAvro, packet("avro metadata"))
         }
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
 
         assertTrue(CustomMimeType("custom") in decoded)
         assertTrue(CustomMimeType("custom2") !in decoded)
@@ -99,7 +99,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(ReservedMimeType(120), packet("reserved metadata"))
             add(WellKnownMimeType.ApplicationAvro, packet("avro metadata"))
         }
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
 
         assertEquals("custom metadata", decoded[CustomMimeType("custom")].readText())
         assertEquals("reserved metadata", decoded[ReservedMimeType(120)].readText())
@@ -113,7 +113,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(ReservedMimeType(120), packet("reserved metadata"))
             add(WellKnownMimeType.ApplicationAvro, packet("avro metadata"))
         }
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
 
         assertNull(decoded.getOrNull(ReservedMimeType(121)))
         assertNull(decoded.getOrNull(CustomMimeType("custom2")))
@@ -133,7 +133,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(WellKnownMimeType.MessageRSocketRouting, packet("routing metadata"))
             add(CustomMimeType("custom"), packet("custom metadata - 2"))
         }
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
 
         assertEquals(5, decoded.entries.size)
 
@@ -193,7 +193,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
             add(WellKnownMimeType.ApplicationJson, packet("{}"))
         }
 
-        val decoded = cm.toPacket(InUseTrackingPool).read(InUseTrackingPool, CompositeMetadata)
+        val decoded = cm.readLoop(CompositeMetadata)
         assertEquals(3, decoded.entries.size)
 
         assertEquals(listOf("tag1", "tag2"), decoded[RoutingMetadata].tags)

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataTest.kt
@@ -183,11 +183,13 @@ class CompositeMetadataTest : TestWithLeakCheck {
     fun testCombine() {
         val cm = buildCompositeMetadata {
             add(RoutingMetadata("tag1", "tag2"))
-            add(PerStreamAcceptableDataMimeTypesMetadata(
-                WellKnownMimeType.ApplicationAvro,
-                CustomMimeType("application/custom"),
-                ReservedMimeType(120)
-            ))
+            add(
+                PerStreamAcceptableDataMimeTypesMetadata(
+                    WellKnownMimeType.ApplicationAvro,
+                    CustomMimeType("application/custom"),
+                    ReservedMimeType(120)
+                )
+            )
             add(WellKnownMimeType.ApplicationJson, packet("{}"))
         }
 

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadataTest.kt
@@ -31,7 +31,7 @@ class PerStreamAcceptableDataMimeTypesMetadataTest : TestWithLeakCheck {
             ReservedMimeType(120),
             CustomMimeType("custom2"),
         )
-        val decoded = metadata.toPacket(InUseTrackingPool).read(InUseTrackingPool, PerStreamAcceptableDataMimeTypesMetadata)
+        val decoded = metadata.readLoop(PerStreamAcceptableDataMimeTypesMetadata)
         assertEquals(WellKnownMimeType.MessageRSocketAcceptMimeTypes, decoded.mimeType)
         assertEquals(6, decoded.types.size)
         assertEquals(

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadataTest.kt
@@ -24,7 +24,7 @@ class PerStreamDataMimeTypeMetadataTest : TestWithLeakCheck {
     @Test
     fun encodeReserved() {
         val metadata = PerStreamDataMimeTypeMetadata(ReservedMimeType(110))
-        val decoded = metadata.toPacket(InUseTrackingPool).read(InUseTrackingPool, PerStreamDataMimeTypeMetadata)
+        val decoded = metadata.readLoop(PerStreamDataMimeTypeMetadata)
         assertEquals(WellKnownMimeType.MessageRSocketMimeType, decoded.mimeType)
         assertEquals(ReservedMimeType(110), decoded.type)
     }
@@ -32,7 +32,7 @@ class PerStreamDataMimeTypeMetadataTest : TestWithLeakCheck {
     @Test
     fun encodeCustom() {
         val metadata = PerStreamDataMimeTypeMetadata(CustomMimeType("custom-2"))
-        val decoded = metadata.toPacket(InUseTrackingPool).read(InUseTrackingPool, PerStreamDataMimeTypeMetadata)
+        val decoded = metadata.readLoop(PerStreamDataMimeTypeMetadata)
         assertEquals(WellKnownMimeType.MessageRSocketMimeType, decoded.mimeType)
         assertEquals(CustomMimeType("custom-2"), decoded.type)
     }
@@ -40,7 +40,7 @@ class PerStreamDataMimeTypeMetadataTest : TestWithLeakCheck {
     @Test
     fun encodeWellKnown() {
         val metadata = PerStreamDataMimeTypeMetadata(WellKnownMimeType.ApplicationGraphql)
-        val decoded = metadata.toPacket(InUseTrackingPool).read(InUseTrackingPool, PerStreamDataMimeTypeMetadata)
+        val decoded = metadata.readLoop(PerStreamDataMimeTypeMetadata)
         assertEquals(WellKnownMimeType.MessageRSocketMimeType, decoded.mimeType)
         assertEquals(WellKnownMimeType.ApplicationGraphql, decoded.type)
     }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/RoutingMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/RoutingMetadataTest.kt
@@ -24,7 +24,7 @@ class RoutingMetadataTest : TestWithLeakCheck {
     fun encodeMetadata() {
         val tags = listOf("ws://localhost:8080/rsocket", "x".repeat(200))
         val metadata = RoutingMetadata(tags)
-        val decodedMetadata = metadata.toPacket(InUseTrackingPool).read(InUseTrackingPool, RoutingMetadata)
+        val decodedMetadata = metadata.readLoop(RoutingMetadata)
         assertEquals(tags, decodedMetadata.tags)
     }
 

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/Util.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/Util.kt
@@ -18,4 +18,4 @@ package io.rsocket.kotlin.metadata
 
 import io.rsocket.kotlin.test.*
 
-fun <M : Metadata> Metadata.readLoop(reader: MetadataReader<M>): M = toPacket(InUseTrackingPool).read(InUseTrackingPool, reader)
+fun <M : Metadata> Metadata.readLoop(reader: MetadataReader<M>): M = toPacket(InUseTrackingPool).read(reader, InUseTrackingPool)

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadataTest.kt
@@ -52,7 +52,8 @@ class AuthMetadataTest : TestWithLeakCheck {
 
     @Test
     fun encodeBearer() {
-        val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpYXQxIjoxNTE2MjM5MDIyLCJpYXQyIjoxNTE2MjM5MDIyLCJpYXQzIjoxNTE2MjM5MDIyLCJpYXQ0IjoxNTE2MjM5MDIyfQ.ljYuH-GNyyhhLcx-rHMchRkGbNsR2_4aSxo8XjrYrSM";
+        val token =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpYXQxIjoxNTE2MjM5MDIyLCJpYXQyIjoxNTE2MjM5MDIyLCJpYXQzIjoxNTE2MjM5MDIyLCJpYXQ0IjoxNTE2MjM5MDIyfQ.ljYuH-GNyyhhLcx-rHMchRkGbNsR2_4aSxo8XjrYrSM";
         val metadata = BearerAuthMetadata(token)
         val decoded = metadata.readLoop(BearerAuthMetadata)
 

--- a/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/internal/currentMillis.kt
+++ b/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/internal/currentMillis.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.keepalive
+package io.rsocket.kotlin.internal
 
 import kotlin.js.*
 

--- a/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/logging/DefaultLoggerFactory.kt
+++ b/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/logging/DefaultLoggerFactory.kt
@@ -16,9 +16,14 @@
 
 package io.rsocket.kotlin.logging
 
-actual val DefaultLoggerFactory: LoggerFactory get() = ConsoleLogger
+import io.rsocket.kotlin.*
 
-class ConsoleLogger(
+@RSocketLoggingApi
+internal actual val DefaultLoggerFactory: LoggerFactory
+    get() = ConsoleLogger
+
+@RSocketLoggingApi
+public class ConsoleLogger(
     override val tag: String,
     private val minLevel: LoggingLevel = LoggingLevel.INFO,
 ) : Logger {
@@ -27,16 +32,16 @@ class ConsoleLogger(
         val meta = "[$level] ($tag)"
         when (level) {
             LoggingLevel.ERROR -> throwable?.let { console.error(meta, message, "Error:", it) } ?: console.error(meta, message)
-            LoggingLevel.WARN -> throwable?.let { console.warn(meta, message, "Error:", it) } ?: console.warn(meta, message)
-            LoggingLevel.INFO -> throwable?.let { console.info(meta, message, "Error:", it) } ?: console.info(meta, message)
+            LoggingLevel.WARN  -> throwable?.let { console.warn(meta, message, "Error:", it) } ?: console.warn(meta, message)
+            LoggingLevel.INFO  -> throwable?.let { console.info(meta, message, "Error:", it) } ?: console.info(meta, message)
             LoggingLevel.DEBUG -> throwable?.let { console.log(meta, message, "Error:", it) } ?: console.log(meta, message)
             LoggingLevel.TRACE -> throwable?.let { console.log(meta, message, "Error:", it) } ?: console.log(meta, message)
         }
     }
 
-    companion object : LoggerFactory {
+    public companion object : LoggerFactory {
         override fun logger(tag: String): Logger = ConsoleLogger(tag)
 
-        fun withLevel(minLevel: LoggingLevel): LoggerFactory = LoggerFactory { ConsoleLogger(it, minLevel) }
+        public fun withLevel(minLevel: LoggingLevel): LoggerFactory = LoggerFactory { ConsoleLogger(it, minLevel) }
     }
 }

--- a/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/internal/currentMillis.kt
+++ b/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/internal/currentMillis.kt
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.keepalive
+package io.rsocket.kotlin.internal
 
 internal actual fun currentMillis(): Long = System.currentTimeMillis()

--- a/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/logging/DefaultLoggerFactory.kt
+++ b/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/logging/DefaultLoggerFactory.kt
@@ -16,21 +16,25 @@
 
 package io.rsocket.kotlin.logging
 
+import io.rsocket.kotlin.*
 import java.util.logging.*
 import java.util.logging.Level as JLevel
 import java.util.logging.Logger as JLogger
 
-actual val DefaultLoggerFactory: LoggerFactory get() = JavaLogger
+@RSocketLoggingApi
+internal actual val DefaultLoggerFactory: LoggerFactory
+    get() = JavaLogger
 
-class JavaLogger(override val tag: String) : Logger {
+@RSocketLoggingApi
+public class JavaLogger(override val tag: String) : Logger {
     private val jLogger = JLogger.getLogger(tag)
 
     private val LoggingLevel.jLevel: JLevel
         get() = when (this) {
             LoggingLevel.TRACE -> JLevel.FINEST
             LoggingLevel.DEBUG -> JLevel.FINE
-            LoggingLevel.INFO -> JLevel.INFO
-            LoggingLevel.WARN -> JLevel.WARNING
+            LoggingLevel.INFO  -> JLevel.INFO
+            LoggingLevel.WARN  -> JLevel.WARNING
             LoggingLevel.ERROR -> JLevel.SEVERE
         }
 
@@ -46,7 +50,7 @@ class JavaLogger(override val tag: String) : Logger {
         jLogger.log(record)
     }
 
-    companion object : LoggerFactory {
+    public companion object : LoggerFactory {
         override fun logger(tag: String): Logger = JavaLogger(tag)
     }
 }

--- a/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/internal/currentMillis.kt
+++ b/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/internal/currentMillis.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.keepalive
+package io.rsocket.kotlin.internal
 
 import kotlin.system.*
 

--- a/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/logging/DefaultLoggerFactory.kt
+++ b/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/logging/DefaultLoggerFactory.kt
@@ -16,4 +16,8 @@
 
 package io.rsocket.kotlin.logging
 
-actual val DefaultLoggerFactory: LoggerFactory get() = PrintLogger
+import io.rsocket.kotlin.*
+
+@RSocketLoggingApi
+public actual val DefaultLoggerFactory: LoggerFactory
+    get() = PrintLogger

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/SuspendTest.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/SuspendTest.kt
@@ -21,10 +21,10 @@ import kotlin.coroutines.*
 import kotlin.time.*
 
 interface SuspendTest {
-    val testTimeout: Duration get() = 1.minutes
+    val testTimeout: Duration get() = Duration.minutes(1)
 
-    val beforeTimeout: Duration get() = 10.seconds
-    val afterTimeout: Duration get() = 10.seconds
+    val beforeTimeout: Duration get() = Duration.seconds(10)
+    val afterTimeout: Duration get() = Duration.seconds(10)
 
     val debug: Boolean get() = true //change to turn off debug logs locally (useful for CI)
 

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestConnection.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestConnection.kt
@@ -51,10 +51,12 @@ class TestConnection : Connection, CoroutineScope {
         return receiveChannel.receive()
     }
 
+    @Suppress("INVISIBLE_MEMBER") //for toPacket
     suspend fun sendToReceiver(vararg frames: Frame) {
         frames.forEach { receiveChannel.send(it.toPacket(InUseTrackingPool)) }
     }
 
+    @Suppress("INVISIBLE_MEMBER") //for readFrame
     private fun sentAsFlow(): Flow<Frame> = sendChannel.receiveAsFlow().map { it.readFrame(InUseTrackingPool) }
 
     suspend fun test(validate: suspend FlowTurbine<Frame>.() -> Unit) {

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.*
 import kotlin.time.*
 
 abstract class TransportTest : SuspendTest, TestWithLeakCheck {
-    override val testTimeout: Duration = 2.minutes
+    override val testTimeout: Duration = Duration.minutes(2)
 
     lateinit var client: RSocket //should be assigned in `before`
 
@@ -56,13 +56,13 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
     }
 
     @Test
-    fun requestChannel0() = test(10.seconds) {
+    fun requestChannel0() = test(Duration.seconds(10)) {
         val list = client.requestChannel(payload(0), emptyFlow()).toList()
         assertTrue(list.isEmpty())
     }
 
     @Test
-    fun requestChannel1() = test(10.seconds) {
+    fun requestChannel1() = test(Duration.seconds(10)) {
         val list = client.requestChannel(payload(0), flowOf(payload(0))).onEach { it.release() }.toList()
         assertEquals(1, list.size)
     }
@@ -221,7 +221,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
             loggerFactory = NoopLogger
 
             connectionConfig {
-                keepAlive = KeepAlive(10.minutes, 100.minutes)
+                keepAlive = KeepAlive(Duration.minutes(10), Duration.minutes(100))
             }
         }
 

--- a/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/WebSocketClientTransport.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/WebSocketClientTransport.kt
@@ -32,6 +32,7 @@ public fun WebSocketClientTransport(
     request: HttpRequestBuilder.() -> Unit,
 ): ClientTransport = ClientTransport {
     val session = httpClient.webSocketSession(request)
+    @Suppress("INVISIBLE_MEMBER")
     WebSocketConnection(session)
 }
 

--- a/rsocket-transport-ktor/rsocket-transport-ktor-server/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/server/Routing.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-server/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/server/Routing.kt
@@ -23,14 +23,6 @@ import io.rsocket.kotlin.*
 public fun Route.rSocket(
     path: String? = null,
     protocol: String? = null,
-    block: suspend ConnectionAcceptorContext.() -> RSocket
-) {
-    rSocket(path, protocol, ConnectionAcceptor(block))
-}
-
-public fun Route.rSocket(
-    path: String? = null,
-    protocol: String? = null,
     acceptor: ConnectionAcceptor,
 ) {
     val serverTransport = serverTransport(path, protocol)

--- a/rsocket-transport-ktor/rsocket-transport-ktor-server/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/server/WebSocketServerTransport.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-server/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/server/WebSocketServerTransport.kt
@@ -29,10 +29,12 @@ internal fun Route.serverTransport(
 ): ServerTransport<Unit> = ServerTransport { acceptor ->
     when (path) {
         null -> webSocket(protocol) {
+            @Suppress("INVISIBLE_MEMBER")
             val connection = WebSocketConnection(this)
             acceptor(connection)
         }
         else -> webSocket(path, protocol) {
+            @Suppress("INVISIBLE_MEMBER")
             val connection = WebSocketConnection(this)
             acceptor(connection)
         }

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpClientTransport.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpClientTransport.kt
@@ -21,7 +21,6 @@ package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.util.*
 import io.ktor.util.network.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpClientTransport.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpClientTransport.kt
@@ -26,7 +26,6 @@ import io.ktor.util.network.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 
-@InternalAPI //because of selector
 public fun TcpClientTransport(
     selector: SelectorManager,
     hostname: String, port: Int,
@@ -34,7 +33,6 @@ public fun TcpClientTransport(
     configure: SocketOptions.TCPClientSocketOptions.() -> Unit = {},
 ): ClientTransport = TcpClientTransport(selector, NetworkAddress(hostname, port), intercept, configure)
 
-@InternalAPI //because of selector
 public fun TcpClientTransport(
     selector: SelectorManager,
     remoteAddress: NetworkAddress,

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
@@ -20,8 +20,8 @@ import io.ktor.network.sockets.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import io.ktor.utils.io.core.internal.*
 import io.rsocket.kotlin.*
+import io.rsocket.kotlin.Connection
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.internal.*
 import kotlinx.coroutines.*

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpConnection.kt
@@ -22,7 +22,6 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.Connection
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.internal.*
 import kotlinx.coroutines.*
@@ -33,7 +32,7 @@ import kotlin.native.concurrent.*
 @SharedImmutable
 internal val ignoreExceptionHandler = CoroutineExceptionHandler { _, _ -> }
 
-@OptIn(TransportApi::class, DangerousInternalIoApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(TransportApi::class)
 internal class TcpConnection(private val socket: Socket) : Connection, CoroutineScope {
     override val job: Job = socket.socketContext
     override val coroutineContext: CoroutineContext = job + Dispatchers.Unconfined + ignoreExceptionHandler

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTransport.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTransport.kt
@@ -20,19 +20,17 @@ package io.rsocket.kotlin.transport.ktor
 
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.ktor.util.*
 import io.ktor.util.network.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 
-@InternalAPI //because of selector
 public fun TcpServerTransport(
     selector: SelectorManager,
     hostname: String = "0.0.0.0", port: Int = 0,
     configure: SocketOptions.AcceptorOptions.() -> Unit = {},
 ): ServerTransport<Job> = TcpServerTransport(selector, NetworkAddress(hostname, port), configure)
 
-@InternalAPI //because of selector
+@OptIn(DelicateCoroutinesApi::class) //TODO ?
 public fun TcpServerTransport(
     selector: SelectorManager,
     localAddress: NetworkAddress? = null,

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
@@ -22,7 +22,7 @@ import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 
 @TransportApi
-public class WebSocketConnection(private val session: WebSocketSession) : Connection {
+internal class WebSocketConnection(private val session: WebSocketSession) : Connection {
 
     override val job: Job = session.coroutineContext.job
 

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
@@ -46,7 +46,7 @@ class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
         install(ClientRSocketSupport) {
             connector = RSocketConnector {
                 connectionConfig {
-                    keepAlive = KeepAlive(500.milliseconds)
+                    keepAlive = KeepAlive(500)
                 }
             }
         }

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlin.random.*
 import kotlin.test.*
-import kotlin.time.*
 import io.ktor.client.engine.cio.CIO as ClientCIO
 import io.ktor.client.features.websocket.WebSockets as ClientWebSockets
 import io.ktor.server.cio.CIO as ServerCIO

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketTransportTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketTransportTest.kt
@@ -24,9 +24,8 @@ import io.ktor.server.engine.*
 import io.ktor.websocket.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.test.*
-import io.rsocket.kotlin.transport.ServerTransport
+import io.rsocket.kotlin.transport.*
 import io.rsocket.kotlin.transport.ktor.client.*
-import io.rsocket.kotlin.transport.ktor.server.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlin.random.*

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalConnection.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalConnection.kt
@@ -23,7 +23,7 @@ import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 
-@OptIn(DangerousInternalIoApi::class, TransportApi::class)
+@OptIn(TransportApi::class)
 internal class LocalConnection(
     private val sender: SendChannel<ByteReadPacket>,
     private val receiver: ReceiveChannel<ByteReadPacket>,

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -44,19 +44,10 @@ internal constructor(
         val clientChannel = SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
         val serverChannel = SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
         val connectionJob = Job(job)
-        val channelCloseJob = Job(job)
         connectionJob.invokeOnCompletion {
             val error = CancellationException("Connection failed", it)
             clientChannel.cancel(error)
             serverChannel.cancel(error)
-            CoroutineScope(job).launch {
-                while (!clientChannel.isClosedForReceive || !clientChannel.isClosedForSend
-                    || !serverChannel.isClosedForReceive || !serverChannel.isClosedForSend
-                ) {
-                    delay(1)
-                }
-                channelCloseJob.complete()
-            }
         }
         val clientConnection = LocalConnection(serverChannel, clientChannel, pool, connectionJob)
         val serverConnection = LocalConnection(clientChannel, serverChannel, pool, connectionJob)

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -55,6 +55,7 @@ internal constructor(
         return clientConnection
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun start(accept: suspend (Connection) -> Unit): Job =
         GlobalScope.launch(job + Dispatchers.Unconfined, CoroutineStart.UNDISPATCHED) {
             supervisorScope {

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -27,15 +27,9 @@ import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 
-@Suppress("FunctionName")
-@OptIn(DangerousInternalIoApi::class)
-public fun LocalServer(parentJob: Job? = null): LocalServer = LocalServer(parentJob, ChunkBuffer.Pool)
-
-public class LocalServer
-@DangerousInternalIoApi
-internal constructor(
+public class LocalServer(
     parentJob: Job?,
-    private val pool: ObjectPool<ChunkBuffer>,
+    private val pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool,
 ) : ServerTransport<Job>, ClientTransport {
     public val job: Job = SupervisorJob(parentJob)
     private val connections = Channel<Connection>()

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -22,10 +22,10 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
-import kotlin.native.concurrent.*
 
 @Suppress("FunctionName")
 @OptIn(DangerousInternalIoApi::class)
@@ -41,7 +41,10 @@ internal constructor(
     private val connections = Channel<Connection>()
 
     override suspend fun connect(): Connection {
+        @Suppress("INVISIBLE_MEMBER")
         val clientChannel = SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
+
+        @Suppress("INVISIBLE_MEMBER")
         val serverChannel = SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
         val connectionJob = Job(job)
         connectionJob.invokeOnCompletion {
@@ -65,9 +68,3 @@ internal constructor(
             }
         }
 }
-
-@SharedImmutable
-private val onUndeliveredCloseable: (Closeable) -> Unit = Closeable::close
-
-@Suppress("FunctionName")
-private fun <E : Closeable> SafeChannel(capacity: Int): Channel<E> = Channel(capacity, onUndeliveredElement = onUndeliveredCloseable)

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 
 public class LocalServer(
-    parentJob: Job?,
+    parentJob: Job? = null,
     private val pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool,
 ) : ServerTransport<Job>, ClientTransport {
     public val job: Job = SupervisorJob(parentJob)


### PR DESCRIPTION
* revert #172 
* remove unused `data` packet from `ErrorFrame`
* change `Frame.type` from field to getter
* expose `FrameType` to public
* cleanup usages of `DangerousInternalIoApi` on `ChunkBuffer` - after ktor 1.6.0 it's no more `internal`
* move some classes to internal package
* change visibility from public to internal for some functions and deduplicate several functions (like `SafeChannel`) and use hack with `invisible reference` to use internal declarations in other modules - TODO may be find some better way to share such `internal` declarations between core and TCP/WS/Local transports implementations
* use `sealed` interfaces for mime-types and payload builders
* use `fun` interfaces in places with `suspend fun`
* make logging api explicitly public and provide temporary `experimental` annotation for it
* enable `explicitApi` mode