### PR TITLE
provides fragmentation and reassembly

### DIFF
--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.*
 @OptIn(TransportApi::class, RSocketLoggingApi::class)
 public class RSocketConnector internal constructor(
     private val loggerFactory: LoggerFactory,
+    private val maxFragmentSize: Int,
     private val interceptors: Interceptors,
     private val connectionConfigProvider: () -> ConnectionConfig,
     private val acceptor: ConnectionAcceptor,
@@ -61,6 +62,7 @@ public class RSocketConnector internal constructor(
         try {
             val requester = connection.connect(
                 isServer = false,
+                maxFragmentSize = maxFragmentSize,
                 interceptors = interceptors,
                 connectionConfig = connectionConfig,
                 acceptor = acceptor

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -26,6 +26,13 @@ import kotlinx.coroutines.*
 public class RSocketConnectorBuilder internal constructor() {
     @RSocketLoggingApi
     public var loggerFactory: LoggerFactory = DefaultLoggerFactory
+    public var maxFragmentSize: Int = 0
+        set(value) {
+            require(value == 0 || value >= 64) {
+                "maxFragmentSize should be zero (no fragmentation) or greater than or equal to 64, but was $value"
+            }
+            field = value
+        }
 
     private val connectionConfig: ConnectionConfigBuilder = ConnectionConfigBuilder()
     private val interceptors: InterceptorsBuilder = InterceptorsBuilder()
@@ -96,6 +103,7 @@ public class RSocketConnectorBuilder internal constructor() {
     @OptIn(RSocketLoggingApi::class)
     internal fun build(): RSocketConnector = RSocketConnector(
         loggerFactory,
+        maxFragmentSize,
         interceptors.build(),
         connectionConfig.producer(),
         acceptor ?: defaultAcceptor,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.*
 @OptIn(TransportApi::class, RSocketLoggingApi::class)
 public class RSocketServer internal constructor(
     private val loggerFactory: LoggerFactory,
+    private val maxFragmentSize: Int,
     private val interceptors: Interceptors,
 ) {
 
@@ -44,6 +45,7 @@ public class RSocketServer internal constructor(
             else                                  -> try {
                 connect(
                     isServer = true,
+                    maxFragmentSize = maxFragmentSize,
                     interceptors = interceptors,
                     connectionConfig = ConnectionConfig(
                         keepAlive = setupFrame.keepAlive,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServerBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServerBuilder.kt
@@ -22,6 +22,13 @@ import io.rsocket.kotlin.logging.*
 public class RSocketServerBuilder internal constructor() {
     @RSocketLoggingApi
     public var loggerFactory: LoggerFactory = DefaultLoggerFactory
+    public var maxFragmentSize: Int = 0
+        set(value) {
+            require(value == 0 || value >= 64) {
+                "maxFragmentSize should be zero (no fragmentation) or greater than or equal to 64, but was $value"
+            }
+            field = value
+        }
 
     private val interceptors: InterceptorsBuilder = InterceptorsBuilder()
 
@@ -30,7 +37,7 @@ public class RSocketServerBuilder internal constructor() {
     }
 
     @OptIn(RSocketLoggingApi::class)
-    internal fun build(): RSocketServer = RSocketServer(loggerFactory, interceptors.build())
+    internal fun build(): RSocketServer = RSocketServer(loggerFactory, maxFragmentSize, interceptors.build())
 }
 
 public fun RSocketServer(configure: RSocketServerBuilder.() -> Unit = {}): RSocketServer {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/FrameSender.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/FrameSender.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.internal
+
+import io.ktor.utils.io.core.*
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
+import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.payload.*
+import kotlinx.coroutines.*
+import kotlin.math.*
+
+private const val lengthSize = 3
+private const val headerSize = 6
+private const val fragmentOffset = lengthSize + headerSize
+private const val fragmentOffsetWithMetadata = fragmentOffset + lengthSize
+
+internal class FrameSender(
+    private val prioritizer: Prioritizer,
+    private val pool: ObjectPool<ChunkBuffer>,
+    private val maxFragmentSize: Int
+) {
+
+    suspend fun sendKeepAlive(respond: Boolean, lastPosition: Long, data: ByteReadPacket): Unit =
+        prioritizer.send(KeepAliveFrame(respond, lastPosition, data))
+
+    suspend fun sendMetadataPush(metadata: ByteReadPacket): Unit = prioritizer.send(MetadataPushFrame(metadata))
+
+    suspend fun sendCancel(id: Int): Unit = withContext(NonCancellable) { prioritizer.send(CancelFrame(id)) }
+    suspend fun sendError(id: Int, throwable: Throwable): Unit = withContext(NonCancellable) { prioritizer.send(ErrorFrame(id, throwable)) }
+    suspend fun sendRequestN(id: Int, n: Int): Unit = prioritizer.send(RequestNFrame(id, n))
+
+    suspend fun sendRequestPayload(type: FrameType, streamId: Int, payload: Payload, initialRequest: Int = 0) {
+        sendFragmented(type, streamId, payload, false, false, initialRequest)
+    }
+
+    suspend fun sendNextPayload(streamId: Int, payload: Payload) {
+        sendFragmented(FrameType.Payload, streamId, payload, false, true, 0)
+    }
+
+    suspend fun sendNextCompletePayload(streamId: Int, payload: Payload) {
+        sendFragmented(FrameType.Payload, streamId, payload, true, true, 0)
+    }
+
+    suspend fun sendCompletePayload(streamId: Int) {
+        sendFragmented(FrameType.Payload, streamId, Payload.Empty, true, false, 0)
+    }
+
+    private suspend fun sendFragmented(
+        type: FrameType,
+        streamId: Int,
+        payload: Payload,
+        complete: Boolean,
+        next: Boolean,
+        initialRequest: Int
+    ) {
+        //TODO release on fail ?
+        if (!payload.isFragmentable(type.hasInitialRequest)) {
+            prioritizer.send(RequestFrame(type, streamId, false, complete, next, initialRequest, payload))
+            return
+        }
+
+        val data = payload.data
+        val metadata = payload.metadata
+
+        val fragmentSize = maxFragmentSize - fragmentOffset - (if (type.hasInitialRequest) Int.SIZE_BYTES else 0)
+
+        var first = true
+        var remaining = fragmentSize
+        if (metadata != null) remaining -= lengthSize
+
+        do {
+            val metadataFragment = if (metadata != null && metadata.isNotEmpty) {
+                if (!first) remaining -= lengthSize
+                val length = min(metadata.remaining.toInt(), remaining)
+                remaining -= length
+                metadata.readPacket(pool, length)
+            } else null
+
+            val dataFragment = if (remaining > 0 && data.isNotEmpty) {
+                val length = min(data.remaining.toInt(), remaining)
+                remaining -= length
+                data.readPacket(pool, length)
+            } else {
+                ByteReadPacket.Empty
+            }
+
+            val fType = if (first && type.isRequestType) type else FrameType.Payload
+            val fragment = Payload(dataFragment, metadataFragment)
+            val follows = metadata != null && metadata.isNotEmpty || data.isNotEmpty
+            prioritizer.send(RequestFrame(fType, streamId, follows, (!follows && complete), !fType.isRequestType, initialRequest, fragment))
+            first = false
+            remaining = fragmentSize
+        } while (follows)
+    }
+
+    private fun Payload.isFragmentable(hasInitialRequest: Boolean) = when (maxFragmentSize) {
+        0    -> false
+        else -> when (val meta = metadata) {
+            null -> data.remaining > maxFragmentSize - fragmentOffset - (if (hasInitialRequest) Int.SIZE_BYTES else 0)
+            else -> data.remaining + meta.remaining > maxFragmentSize - fragmentOffsetWithMetadata - (if (hasInitialRequest) Int.SIZE_BYTES else 0)
+        }
+    }
+
+}

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Prioritizer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Prioritizer.kt
@@ -30,7 +30,7 @@ internal class Prioritizer {
     private val commonChannel = SafeChannel<Frame>(Channel.UNLIMITED)
 
     suspend fun send(frame: Frame) {
-        if (frame.type != FrameType.Cancel && frame.type != FrameType.Error) currentCoroutineContext().ensureActive()
+        currentCoroutineContext().ensureActive()
         val channel = if (frame.streamId == 0) priorityChannel else commonChannel
         channel.send(frame)
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestChannelFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestChannelFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
@@ -27,7 +29,8 @@ internal class RequesterRequestChannelFrameHandler(
     private val limiter: Limiter,
     private val sender: Job,
     private val channel: Channel<Payload>,
-) : RequesterFrameHandler(), SendFrameHandler {
+    pool: ObjectPool<ChunkBuffer>
+) : RequesterFrameHandler(pool), SendFrameHandler {
 
     override fun handleNext(payload: Payload) {
         channel.safeTrySend(payload)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestResponseFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestResponseFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
@@ -23,8 +25,9 @@ import kotlinx.coroutines.*
 internal class RequesterRequestResponseFrameHandler(
     private val id: Int,
     private val streamsStorage: StreamsStorage,
-    private val deferred: CompletableDeferred<Payload>
-) : RequesterFrameHandler() {
+    private val deferred: CompletableDeferred<Payload>,
+    pool: ObjectPool<ChunkBuffer>
+) : RequesterFrameHandler(pool) {
     override fun handleNext(payload: Payload) {
         deferred.complete(payload)
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestStreamFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestStreamFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.channels.*
@@ -23,8 +25,9 @@ import kotlinx.coroutines.channels.*
 internal class RequesterRequestStreamFrameHandler(
     private val id: Int,
     private val streamsStorage: StreamsStorage,
-    private val channel: Channel<Payload>
-) : RequesterFrameHandler() {
+    private val channel: Channel<Payload>,
+    pool: ObjectPool<ChunkBuffer>
+) : RequesterFrameHandler(pool) {
 
     override fun handleNext(payload: Payload) {
         channel.safeTrySend(payload)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderFireAndForgetFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderFireAndForgetFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
@@ -24,7 +26,8 @@ internal class ResponderFireAndForgetFrameHandler(
     private val id: Int,
     private val streamsStorage: StreamsStorage,
     private val responder: RSocketResponder,
-) : ResponderFrameHandler() {
+    pool: ObjectPool<ChunkBuffer>
+) : ResponderFrameHandler(pool) {
 
     override fun start(payload: Payload): Job = responder.handleFireAndForget(payload, this)
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderRequestChannelFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderRequestChannelFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
@@ -26,8 +28,9 @@ internal class ResponderRequestChannelFrameHandler(
     private val id: Int,
     private val streamsStorage: StreamsStorage,
     private val responder: RSocketResponder,
-    initialRequest: Int
-) : ResponderFrameHandler(), ReceiveFrameHandler {
+    initialRequest: Int,
+    pool: ObjectPool<ChunkBuffer>
+) : ResponderFrameHandler(pool), ReceiveFrameHandler {
     val limiter = Limiter(initialRequest)
     val channel = SafeChannel<Payload>(Channel.UNLIMITED)
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderRequestResponseFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderRequestResponseFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
@@ -23,8 +25,9 @@ import kotlinx.coroutines.*
 internal class ResponderRequestResponseFrameHandler(
     private val id: Int,
     private val streamsStorage: StreamsStorage,
-    private val responder: RSocketResponder
-) : ResponderFrameHandler() {
+    private val responder: RSocketResponder,
+    pool: ObjectPool<ChunkBuffer>
+) : ResponderFrameHandler(pool) {
 
     override fun start(payload: Payload): Job = responder.handleRequestResponse(payload, id, this)
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderRequestStreamFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/ResponderRequestStreamFrameHandler.kt
@@ -16,6 +16,8 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
@@ -25,7 +27,8 @@ internal class ResponderRequestStreamFrameHandler(
     private val streamsStorage: StreamsStorage,
     private val responder: RSocketResponder,
     initialRequest: Int,
-) : ResponderFrameHandler() {
+    pool: ObjectPool<ChunkBuffer>
+) : ResponderFrameHandler(pool) {
     val limiter = Limiter(initialRequest)
 
     override fun start(payload: Payload): Job = responder.handleRequestStream(payload, id, this)

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/FrameSenderTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/FrameSenderTest.kt
@@ -1,0 +1,57 @@
+package io.rsocket.kotlin.internal
+
+import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.payload.*
+import io.rsocket.kotlin.test.*
+import kotlin.test.*
+
+class FrameSenderTest : SuspendTest, TestWithLeakCheck {
+
+    private val prioritizer = Prioritizer()
+    private fun sender(maxFragmentSize: Int) = FrameSender(prioritizer, InUseTrackingPool, maxFragmentSize)
+
+    @Test
+    fun testFrameFragmented() = test {
+        val sender = sender(99)
+
+        sender.sendNextPayload(1, buildPayload {
+            data("1234567890".repeat(50))
+        })
+
+        repeat(6) {
+            val frame = prioritizer.receive()
+            assertIs<RequestFrame>(frame)
+            assertTrue(frame.next)
+            assertNull(frame.payload.metadata)
+            if (it != 5) {
+                assertTrue(frame.follows)
+                assertEquals("1234567890".repeat(9), frame.payload.data.readText())
+            } else { //last frame
+                assertFalse(frame.follows)
+                assertEquals("1234567890".repeat(5), frame.payload.data.readText())
+            }
+        }
+    }
+
+    @Test
+    fun testFrameFragmentedFully() = test {
+        val sender = sender(99)
+
+        sender.sendNextPayload(1, buildPayload {
+            data("1234567890".repeat(18))
+        })
+
+        repeat(2) {
+            val frame = prioritizer.receive()
+            assertIs<RequestFrame>(frame)
+            assertTrue(frame.next)
+            assertNull(frame.payload.metadata)
+            assertEquals("1234567890".repeat(9), frame.payload.data.readText())
+            if (it != 1) {
+                assertTrue(frame.follows)
+            } else { //last frame
+                assertFalse(frame.follows)
+            }
+        }
+    }
+}

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/PrioritizerTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/PrioritizerTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.internal
+
+import io.ktor.utils.io.core.*
+import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.test.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class PrioritizerTest : SuspendTest, TestWithLeakCheck {
+    private val prioritizer = Prioritizer()
+
+    @Test
+    fun testOrdering() = test {
+        prioritizer.send(CancelFrame(1))
+        prioritizer.send(CancelFrame(2))
+        prioritizer.send(CancelFrame(3))
+
+        assertEquals(1, prioritizer.receive().streamId)
+        assertEquals(2, prioritizer.receive().streamId)
+        assertEquals(3, prioritizer.receive().streamId)
+    }
+
+    @Test
+    fun testOrderingPriority() = test {
+        prioritizer.send(MetadataPushFrame(ByteReadPacket.Empty))
+        prioritizer.send(KeepAliveFrame(true, 0, ByteReadPacket.Empty))
+
+        assertTrue(prioritizer.receive() is MetadataPushFrame)
+        assertTrue(prioritizer.receive() is KeepAliveFrame)
+    }
+
+    @Test
+    fun testPrioritization() = test {
+        prioritizer.send(CancelFrame(5))
+        prioritizer.send(MetadataPushFrame(ByteReadPacket.Empty))
+        prioritizer.send(CancelFrame(1))
+        prioritizer.send(MetadataPushFrame(ByteReadPacket.Empty))
+
+        assertEquals(0, prioritizer.receive().streamId)
+        assertEquals(0, prioritizer.receive().streamId)
+        assertEquals(5, prioritizer.receive().streamId)
+        assertEquals(1, prioritizer.receive().streamId)
+    }
+
+    @Test
+    fun testAsyncReceive() = test {
+        val deferred = CompletableDeferred<Frame>()
+        launch(anotherDispatcher) {
+            deferred.complete(prioritizer.receive())
+        }
+        delay(100)
+        prioritizer.send(CancelFrame(5))
+        assertTrue(deferred.await() is CancelFrame)
+    }
+
+    @Test
+    fun testPrioritizationAndOrdering() = test {
+        prioritizer.send(RequestNFrame(1, 1))
+        prioritizer.send(MetadataPushFrame(ByteReadPacket.Empty))
+        prioritizer.send(CancelFrame(1))
+        prioritizer.send(KeepAliveFrame(true, 0, ByteReadPacket.Empty))
+
+        assertTrue(prioritizer.receive() is MetadataPushFrame)
+        assertTrue(prioritizer.receive() is KeepAliveFrame)
+        assertTrue(prioritizer.receive() is RequestNFrame)
+        assertTrue(prioritizer.receive() is CancelFrame)
+    }
+
+    @Test
+    fun testReleaseOnClose() = test {
+        val packet = packet("metadata")
+        val payload = payload("data")
+        prioritizer.send(MetadataPushFrame(packet))
+        prioritizer.send(NextPayloadFrame(1, payload))
+
+        assertTrue(packet.isNotEmpty)
+        assertTrue(payload.data.isNotEmpty)
+
+        prioritizer.close(null)
+
+        assertTrue(packet.isEmpty)
+        assertTrue(payload.data.isEmpty)
+    }
+}

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/RSocketRequesterTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/RSocketRequesterTest.kt
@@ -36,6 +36,7 @@ class RSocketRequesterTest : TestWithConnection(), TestWithLeakCheck {
 
         requester = connection.connect(
             isServer = false,
+            maxFragmentSize = 0,
             interceptors = InterceptorsBuilder().build(),
             connectionConfig = ConnectionConfig(
                 keepAlive = KeepAlive(Duration.seconds(1000), Duration.seconds(1000)),

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestResponseFrameHandlerTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestResponseFrameHandlerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.internal.handler
+
+import io.rsocket.kotlin.*
+import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.internal.*
+import io.rsocket.kotlin.payload.*
+import io.rsocket.kotlin.test.*
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class RequesterRequestResponseFrameHandlerTest : SuspendTest, TestWithLeakCheck {
+    private val storage = StreamsStorage(true, InUseTrackingPool)
+    private val deferred = CompletableDeferred<Payload>()
+    private val handler = RequesterRequestResponseFrameHandler(1, storage, deferred, InUseTrackingPool).also { storage.save(1, it) }
+
+    @Test
+    fun testCompleteOnPayloadReceive() = test {
+        handler.handleRequest(RequestFrame(FrameType.Payload, 1, false, false, true, 0, payload("hello")))
+        assertTrue(deferred.isCompleted)
+        assertEquals("hello", deferred.await().data.readText())
+        handler.onReceiveComplete()
+        assertFalse(storage.contains(1))
+    }
+
+    @Test
+    fun testFailOnPayloadReceive() = test {
+        handler.handleError(RSocketError.ApplicationError("failed"))
+        assertTrue(deferred.isCompleted)
+        assertFailsWith(RSocketError.ApplicationError::class, "failed") { deferred.await() }
+        assertFalse(storage.contains(1))
+    }
+
+    @Test
+    fun testFailOnCleanup() = test {
+        handler.cleanup(IllegalStateException("failed"))
+        assertTrue(deferred.isCompleted)
+        assertFailsWith(CancellationException::class, "Connection closed") { deferred.await() }
+    }
+
+    @Test
+    fun testReassembly() = test {
+        handler.handleRequest(RequestFrame(FrameType.Payload, 1, true, false, true, 0, payload("hello")))
+        assertFalse(deferred.isCompleted)
+        handler.handleRequest(RequestFrame(FrameType.Payload, 1, false, false, true, 0, payload(" world")))
+        assertTrue(deferred.isCompleted)
+        assertEquals("hello world", deferred.await().data.readText())
+    }
+}

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/keepalive/KeepAliveTest.kt
@@ -33,6 +33,7 @@ class KeepAliveTest : TestWithConnection(), TestWithLeakCheck {
         keepAlive: KeepAlive = KeepAlive(Duration.milliseconds(100), Duration.seconds(1))
     ): RSocket = connection.connect(
         isServer = false,
+        maxFragmentSize = 0,
         interceptors = InterceptorsBuilder().build(),
         connectionConfig = ConnectionConfig(keepAlive, DefaultPayloadMimeType, Payload.Empty),
         acceptor = { RSocketRequestHandler { } }

--- a/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
+++ b/rsocket-core/src/jsMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
@@ -16,11 +16,15 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import kotlinx.coroutines.*
 
-internal actual abstract class ResponderFrameHandler : BaseResponderFrameHandler() {
+internal actual abstract class ResponderFrameHandler actual constructor(pool: ObjectPool<ChunkBuffer>) : BaseResponderFrameHandler(pool) {
     actual override var job: Job? = null
+    actual override var hasMetadata: Boolean = false
 }
 
-internal actual abstract class RequesterFrameHandler : BaseRequesterFrameHandler() {
+internal actual abstract class RequesterFrameHandler actual constructor(pool: ObjectPool<ChunkBuffer>) : BaseRequesterFrameHandler(pool) {
+    actual override var hasMetadata: Boolean = false
 }

--- a/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
+++ b/rsocket-core/src/jvmMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
@@ -16,11 +16,15 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import kotlinx.coroutines.*
 
-internal actual abstract class ResponderFrameHandler : BaseResponderFrameHandler() {
+internal actual abstract class ResponderFrameHandler actual constructor(pool: ObjectPool<ChunkBuffer>) : BaseResponderFrameHandler(pool) {
     actual override var job: Job? = null
+    actual override var hasMetadata: Boolean = false
 }
 
-internal actual abstract class RequesterFrameHandler : BaseRequesterFrameHandler() {
+internal actual abstract class RequesterFrameHandler actual constructor(pool: ObjectPool<ChunkBuffer>) : BaseRequesterFrameHandler(pool) {
+    actual override var hasMetadata: Boolean = false
 }

--- a/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
+++ b/rsocket-core/src/nativeMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
@@ -16,12 +16,16 @@
 
 package io.rsocket.kotlin.internal.handler
 
+import io.ktor.utils.io.core.internal.*
+import io.ktor.utils.io.pool.*
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 
-internal actual abstract class ResponderFrameHandler : BaseResponderFrameHandler() {
+internal actual abstract class ResponderFrameHandler actual constructor(pool: ObjectPool<ChunkBuffer>) : BaseResponderFrameHandler(pool) {
     actual override var job: Job? by atomic(null)
+    actual override var hasMetadata: Boolean by atomic(false)
 }
 
-internal actual abstract class RequesterFrameHandler : BaseRequesterFrameHandler() {
+internal actual abstract class RequesterFrameHandler actual constructor(pool: ObjectPool<ChunkBuffer>) : BaseRequesterFrameHandler(pool) {
+    actual override var hasMetadata: Boolean by atomic(false)
 }


### PR DESCRIPTION
_**NOTE: Depends on #176**_

* fixes #83 
* move all frame sending functionality into separate class (for future: may be don't use `Frame` class there, and just build final packet with frame, which will be sent to connection)
* implement fragmentation in `FrameSender.sendFragmented` for request frames
* implement simple reassembly logic in `FrameHandler` - TODO some improvements can be added here, like additional checking of consistency like in rsocket-java
* minimal tests added for fragmentation and reassembly - TODO need to add more tests
* TODO need to add more tests for leaked buffers in case of failures