### PR TITLE
improves transport api and lifecycle

### DIFF
--- a/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
+++ b/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
@@ -25,12 +25,12 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlin.random.*
 
-@OptIn(ExperimentalStreamsApi::class)
+@OptIn(ExperimentalStreamsApi::class, DelicateCoroutinesApi::class)
 class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
     private val requestStrategy = PrefetchStrategy(64, 0)
 
+    private val benchJob = Job()
     lateinit var client: RSocket
-    lateinit var server: Job
 
     lateinit var payload: Payload
     lateinit var payloadsFlow: Flow<Payload>
@@ -40,9 +40,7 @@ class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
     override fun setup() {
         payload = createPayload(payloadSize)
         payloadsFlow = flow { repeat(5000) { emit(payloadCopy()) } }
-
-        val localServer = LocalServer()
-        server = RSocketServer().bind(localServer) {
+        val server = RSocketServer().bindIn(CoroutineScope(benchJob + Dispatchers.Unconfined), LocalServerTransport()) {
             RSocketRequestHandler {
                 requestResponse {
                     it.release()
@@ -59,14 +57,14 @@ class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
             }
         }
         client = runBlocking {
-            RSocketConnector().connect(localServer)
+            RSocketConnector().connect(server)
         }
     }
 
     override fun cleanup() {
         runBlocking {
-            client.job.runCatching { cancelAndJoin() }
-            server.runCatching { cancelAndJoin() }
+            client.coroutineContext.job.cancelAndJoin()
+            benchJob.cancelAndJoin()
         }
     }
 

--- a/examples/interactions/src/jvmMain/kotlin/ReconnectExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/ReconnectExample.kt
@@ -25,8 +25,7 @@ import kotlinx.coroutines.flow.*
 
 @TransportApi
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestStream { requestPayload ->
                 val data = requestPayload.data.readText()

--- a/examples/interactions/src/jvmMain/kotlin/ReconnectOnConnectFailExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/ReconnectOnConnectFailExample.kt
@@ -23,8 +23,7 @@ import kotlinx.coroutines.flow.*
 
 @TransportApi
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestStream { requestPayload ->
                 val data = requestPayload.data.readText()

--- a/examples/interactions/src/jvmMain/kotlin/RequestChannelExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/RequestChannelExample.kt
@@ -22,8 +22,7 @@ import kotlinx.coroutines.flow.*
 
 
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestChannel { init, request ->
                 println("Init with: ${init.data.readText()}")

--- a/examples/interactions/src/jvmMain/kotlin/RequestResponseErrorExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/RequestResponseErrorExample.kt
@@ -20,8 +20,7 @@ import io.rsocket.kotlin.transport.local.*
 import kotlinx.coroutines.*
 
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestResponse {
                 val data = it.data.readText()

--- a/examples/interactions/src/jvmMain/kotlin/RequestResponseExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/RequestResponseExample.kt
@@ -20,8 +20,7 @@ import io.rsocket.kotlin.transport.local.*
 import kotlinx.coroutines.*
 
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestResponse {
                 val data = it.data.readText()

--- a/examples/interactions/src/jvmMain/kotlin/RequestStreamExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/RequestStreamExample.kt
@@ -21,8 +21,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestStream {
                 val data = it.data.readText()

--- a/examples/interactions/src/jvmMain/kotlin/ServerRequestExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/ServerRequestExample.kt
@@ -20,8 +20,7 @@ import io.rsocket.kotlin.transport.local.*
 import kotlinx.coroutines.*
 
 fun main(): Unit = runBlocking {
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         RSocketRequestHandler {
             requestResponse {
                 val clientRequest = it.data.readText()

--- a/examples/interactions/src/jvmMain/kotlin/ServerSetupExample.kt
+++ b/examples/interactions/src/jvmMain/kotlin/ServerSetupExample.kt
@@ -23,9 +23,7 @@ import kotlinx.coroutines.flow.*
 
 
 fun main(): Unit = runBlocking {
-
-    val server = LocalServer()
-    RSocketServer().bind(server) {
+    val server = RSocketServer().bindIn(this, LocalServerTransport()) {
         val data = config.setupPayload.metadata?.readText() ?: error("Empty metadata")
         RSocketRequestHandler {
             when (data) {
@@ -43,8 +41,8 @@ fun main(): Unit = runBlocking {
 
     suspend fun client1() {
         val rSocketClient = RSocketConnector().connect(server)
-        rSocketClient.job.join()
-        println("Client 1 canceled: ${rSocketClient.job.isCancelled}")
+        rSocketClient.coroutineContext.job.join()
+        println("Client 1 canceled: ${rSocketClient.coroutineContext.job.isCancelled}")
         try {
             rSocketClient.requestResponse(Payload.Empty)
         } catch (e: Throwable) {

--- a/examples/multiplatform-chat/src/clientMain/kotlin/Api.kt
+++ b/examples/multiplatform-chat/src/clientMain/kotlin/Api.kt
@@ -16,13 +16,12 @@
 
 import io.ktor.client.*
 import io.ktor.client.features.websocket.*
-import io.ktor.network.selector.*
-import io.ktor.util.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.ktor.*
 import io.rsocket.kotlin.transport.ktor.client.*
+import kotlinx.coroutines.*
 
 class Api(rSocket: RSocket) {
     private val proto = ConfiguredProtoBuf
@@ -42,9 +41,10 @@ suspend fun connectToApiUsingWS(name: String): Api {
     return Api(client.rSocket(port = 9000))
 }
 
-@OptIn(InternalAPI::class)
 suspend fun connectToApiUsingTCP(name: String): Api {
-    val transport = TcpClientTransport(SelectorManager(), "0.0.0.0", 8000)
+    val transport = TcpClientTransport("0.0.0.0", 8000, CoroutineExceptionHandler { coroutineContext, throwable ->
+        println("FAIL: $coroutineContext, $throwable")
+    })
     return Api(connector(name).connect(transport))
 }
 

--- a/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
+++ b/examples/multiplatform-chat/src/serverJvmMain/kotlin/App.kt
@@ -15,11 +15,9 @@
  */
 
 import io.ktor.application.*
-import io.ktor.network.selector.*
 import io.ktor.routing.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
-import io.ktor.util.*
 import io.ktor.websocket.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
@@ -31,7 +29,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.*
 
-@OptIn(ExperimentalSerializationApi::class, ExperimentalMetadataApi::class, InternalAPI::class)
+@OptIn(ExperimentalSerializationApi::class, ExperimentalMetadataApi::class, DelicateCoroutinesApi::class)
 fun main() {
     val proto = ConfiguredProtoBuf
     val users = Users()
@@ -97,7 +95,7 @@ fun main() {
     }
 
     //start TCP server
-    rSocketServer.bind(TcpServerTransport(ActorSelectorManager(Dispatchers.IO), port = 9000), acceptor)
+    rSocketServer.bind(TcpServerTransport(port = 8000), acceptor)
 
     //start WS server
     embeddedServer(CIO, port = 9000) {

--- a/playground/src/commonMain/kotlin/TCP.kt
+++ b/playground/src/commonMain/kotlin/TCP.kt
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-import io.ktor.network.selector.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.payload.*
 import io.rsocket.kotlin.transport.ktor.*
-import kotlin.coroutines.*
 
-
-suspend fun runTcpClient(dispatcher: CoroutineContext) {
-    val transport = TcpClientTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
+suspend fun runTcpClient() {
+    val transport = TcpClientTransport("0.0.0.0", 4444)
     RSocketConnector().connect(transport).doSomething()
 }
 
 //to test nodejs tcp server
-suspend fun testNodeJsServer(dispatcher: CoroutineContext) {
-    val transport = TcpClientTransport(SelectorManager(dispatcher), "127.0.0.1", 9000)
+suspend fun testNodeJsServer() {
+    val transport = TcpClientTransport("127.0.0.1", 9000)
     val client = RSocketConnector().connect(transport)
 
     val response = client.requestResponse(buildPayload { data("Hello from JVM") })

--- a/playground/src/jvmMain/kotlin/TcpClientApp.kt
+++ b/playground/src/jvmMain/kotlin/TcpClientApp.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import kotlinx.coroutines.*
+suspend fun main(): Unit = runTcpClient()
 
-suspend fun main(): Unit = runTcpClient(Dispatchers.IO)
-
-//suspend fun main(): Unit = testNodeJsServer(Dispatchers.IO)
+//suspend fun main(): Unit = testNodeJsServer()

--- a/playground/src/jvmMain/kotlin/TcpServerApp.kt
+++ b/playground/src/jvmMain/kotlin/TcpServerApp.kt
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import io.ktor.network.selector.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.transport.ktor.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
 suspend fun runTcpServer(dispatcher: CoroutineContext) {
-    val transport = TcpServerTransport(SelectorManager(dispatcher), "0.0.0.0", 4444)
-    RSocketServer().bind(transport, rSocketAcceptor).join()
+    val transport = TcpServerTransport("0.0.0.0", 4444)
+    RSocketServer().bindIn(CoroutineScope(dispatcher), transport, rSocketAcceptor).handlerJob.join()
 }
 
 suspend fun main(): Unit = runTcpServer(Dispatchers.IO)

--- a/playground/src/nativeMain/kotlin/TcpApp.kt
+++ b/playground/src/nativeMain/kotlin/TcpApp.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import io.ktor.util.*
 import kotlinx.coroutines.*
-import kotlin.coroutines.*
 
-@OptIn(InternalAPI::class)
 fun main() {
     runBlocking {
-        runTcpClient(EmptyCoroutineContext)
+        runTcpClient()
     }
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
@@ -27,9 +27,7 @@ import kotlinx.coroutines.*
  * That interface isn't stable for inheritance.
  */
 @TransportApi
-public interface Connection {
-    public val job: Job
-
+public interface Connection : CoroutineScope {
     public val pool: ObjectPool<ChunkBuffer> get() = ChunkBuffer.Pool
 
     public suspend fun send(packet: ByteReadPacket)
@@ -37,7 +35,7 @@ public interface Connection {
 }
 
 @OptIn(TransportApi::class)
-internal suspend fun Connection.receiveFrame(): Frame = receive().readFrame(pool)
+internal suspend inline fun <T> Connection.receiveFrame(block: (frame: Frame) -> T): T = receive().readFrame(pool).closeOnError(block)
 
 @OptIn(TransportApi::class)
 internal suspend fun Connection.sendFrame(frame: Frame) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
@@ -21,8 +21,7 @@ import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 
-public interface RSocket {
-    public val job: Job
+public interface RSocket : CoroutineScope {
 
     public suspend fun metadataPush(metadata: ByteReadPacket) {
         metadata.release()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -22,6 +22,7 @@ import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
+import kotlin.coroutines.*
 
 public class RSocketConnectorBuilder internal constructor() {
     @RSocketLoggingApi
@@ -117,7 +118,7 @@ public class RSocketConnectorBuilder internal constructor() {
         }
 
         private class EmptyRSocket : RSocket {
-            override val job: Job = Job()
+            override val coroutineContext: CoroutineContext = Job()
         }
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
@@ -16,25 +16,27 @@
 
 package io.rsocket.kotlin.internal
 
-import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.*
 import kotlinx.coroutines.*
 
 @OptIn(TransportApi::class)
-internal suspend inline fun Connection.connect(
+internal suspend inline fun connect(
+    connection: Connection,
     isServer: Boolean,
     maxFragmentSize: Int,
     interceptors: Interceptors,
     connectionConfig: ConnectionConfig,
     acceptor: ConnectionAcceptor
 ): RSocket {
-    val keepAliveHandler = KeepAliveHandler(connectionConfig.keepAlive)
     val prioritizer = Prioritizer()
-    val frameSender = FrameSender(prioritizer, pool, maxFragmentSize)
-    val streamsStorage = StreamsStorage(isServer, pool)
-    val requestJob = SupervisorJob(job)
+    val frameSender = FrameSender(prioritizer, connection.pool, maxFragmentSize)
+    val streamsStorage = StreamsStorage(isServer, connection.pool)
+    val keepAliveHandler = KeepAliveHandler(connectionConfig.keepAlive, frameSender)
+
+    val requestJob = SupervisorJob(connection.coroutineContext[Job])
+    val requestContext = connection.coroutineContext + requestJob
 
     requestJob.invokeOnCompletion {
         prioritizer.close(it)
@@ -42,53 +44,42 @@ internal suspend inline fun Connection.connect(
         connectionConfig.setupPayload.release()
     }
 
-    val requestScope = CoroutineScope(requestJob + Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> })
-    val connectionScope = CoroutineScope(job + Dispatchers.Unconfined + CoroutineExceptionHandler { _, _ -> })
-
-    val requester = interceptors.wrapRequester(RSocketRequester(job, frameSender, streamsStorage, requestScope, pool))
+    val requester = interceptors.wrapRequester(
+        RSocketRequester(requestContext + CoroutineName("rSocket-requester"), frameSender, streamsStorage, connection.pool)
+    )
     val requestHandler = interceptors.wrapResponder(
         with(interceptors.wrapAcceptor(acceptor)) {
             ConnectionAcceptorContext(connectionConfig, requester).accept()
         }
     )
+    val responder = RSocketResponder(requestContext + CoroutineName("rSocket-responder"), frameSender, requestHandler)
 
     // link completing of connection and requestHandler
-    job.invokeOnCompletion { requestHandler.job.cancel("Connection closed", it) }
-    requestHandler.job.invokeOnCompletion { if (it != null) job.cancel("Request handler failed", it) }
+    connection.coroutineContext[Job]?.invokeOnCompletion { requestHandler.cancel("Connection closed", it) }
+    requestHandler.coroutineContext[Job]?.invokeOnCompletion { if (it != null) connection.cancel("Request handler failed", it) }
 
     // start keepalive ticks
-    connectionScope.launch {
-        while (isActive) {
-            keepAliveHandler.tick()
-            prioritizer.send(KeepAliveFrame(true, 0, ByteReadPacket.Empty))
-        }
+    (connection + CoroutineName("rSocket-connection-keep-alive")).launch {
+        while (isActive) keepAliveHandler.tick()
     }
 
     // start sending frames to connection
-    connectionScope.launch {
-        while (isActive) {
-            sendFrame(prioritizer.receive())
-        }
+    (connection + CoroutineName("rSocket-connection-send")).launch {
+        while (isActive) connection.sendFrame(prioritizer.receive())
     }
 
     // start frame handling
-    connectionScope.launch {
-        val rSocketResponder = RSocketResponder(frameSender, requestHandler, requestScope)
-        while (isActive) {
-            receiveFrame().closeOnError { frame ->
-                when (frame.streamId) {
-                    0 -> when (frame) {
-                        is MetadataPushFrame -> rSocketResponder.handleMetadataPush(frame.metadata)
-                        is ErrorFrame        -> job.cancel("Error frame received on 0 stream", frame.throwable)
-                        is KeepAliveFrame    -> {
-                            keepAliveHandler.mark()
-                            if (frame.respond) prioritizer.send(KeepAliveFrame(false, 0, frame.data)) else Unit
-                        }
-                        is LeaseFrame        -> frame.release().also { error("lease isn't implemented") }
-                        else                 -> frame.release()
-                    }
-                    else -> streamsStorage.handleFrame(frame, rSocketResponder)
+    (connection + CoroutineName("rSocket-connection-receive")).launch {
+        while (isActive) connection.receiveFrame { frame ->
+            when (frame.streamId) {
+                0 -> when (frame) {
+                    is MetadataPushFrame -> responder.handleMetadataPush(frame.metadata)
+                    is ErrorFrame        -> connection.cancel("Error frame received on 0 stream", frame.throwable)
+                    is KeepAliveFrame    -> keepAliveHandler.mark(frame)
+                    is LeaseFrame        -> frame.release().also { error("lease isn't implemented") }
+                    else                 -> frame.release()
                 }
+                else -> streamsStorage.handleFrame(frame, responder)
             }
         }
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/StreamsStorage.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/StreamsStorage.kt
@@ -66,7 +66,7 @@ internal class StreamsStorage(private val isServer: Boolean, private val pool: O
                         FrameType.RequestChannel  -> ResponderRequestChannelFrameHandler(id, this, responder, initialRequest, pool)
                         else                      -> error("Wrong request frame type") // should never happen
                     }
-                    handlers[id] = handler
+                    save(id, handler)
                     handler.handleRequest(frame)
                 }
             }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ClientTransport.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ClientTransport.kt
@@ -17,8 +17,20 @@
 package io.rsocket.kotlin.transport
 
 import io.rsocket.kotlin.*
+import kotlinx.coroutines.*
+import kotlin.coroutines.*
 
-public fun interface ClientTransport {
+public fun interface ClientTransport : CoroutineScope {
+    override val coroutineContext: CoroutineContext get() = EmptyCoroutineContext
+
     @TransportApi
     public suspend fun connect(): Connection
+}
+
+@OptIn(TransportApi::class)
+public fun ClientTransport(coroutineContext: CoroutineContext, transport: ClientTransport): ClientTransport = object : ClientTransport {
+    override val coroutineContext: CoroutineContext get() = coroutineContext
+
+    @TransportApi
+    override suspend fun connect(): Connection = transport.connect()
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ServerTransport.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ServerTransport.kt
@@ -17,8 +17,9 @@
 package io.rsocket.kotlin.transport
 
 import io.rsocket.kotlin.*
+import kotlinx.coroutines.*
 
 public fun interface ServerTransport<T> {
     @TransportApi
-    public fun start(accept: suspend (Connection) -> Unit): T
+    public fun CoroutineScope.start(accept: suspend CoroutineScope.(Connection) -> Unit): T
 }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/ConnectionEstablishmentTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/ConnectionEstablishmentTest.kt
@@ -64,10 +64,10 @@ class ConnectionEstablishmentTest : SuspendTest, TestWithLeakCheck {
                 assertEquals(errorMessage, frame.throwable.message)
             }
             val sender = sendingRSocket.await()
-            assertFalse(sender.job.isActive)
+            assertFalse(sender.isActive)
             expectNoEventsIn(100)
         }
-        val error = connection.job.getCancellationException().cause
+        val error = connection.coroutineContext.job.getCancellationException().cause
         assertTrue(error is RSocketError.Setup.Rejected)
         assertEquals(errorMessage, error.message)
     }
@@ -88,7 +88,6 @@ class ConnectionEstablishmentTest : SuspendTest, TestWithLeakCheck {
                 }
             }.connect { connection }
         }
-        println(p.data)
         assertTrue(p.data.isEmpty)
     }
 

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
@@ -21,9 +21,10 @@ import io.rsocket.kotlin.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlin.coroutines.*
 
 class TestRSocket : RSocket {
-    override val job: Job = Job()
+    override val coroutineContext: CoroutineContext = Job()
 
     override suspend fun metadataPush(metadata: ByteReadPacket): Unit = metadata.release()
 

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestWithConnection.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestWithConnection.kt
@@ -22,6 +22,6 @@ abstract class TestWithConnection : SuspendTest {
     val connection: TestConnection = TestConnection()
 
     override suspend fun after() {
-        connection.job.cancelAndJoin()
+        connection.coroutineContext.job.cancelAndJoin()
     }
 }

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
@@ -32,7 +32,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
     lateinit var client: RSocket //should be assigned in `before`
 
     override suspend fun after() {
-        client.job.cancelAndJoin()
+        client.coroutineContext.job.cancelAndJoin()
     }
 
     @Test

--- a/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/WebSocketClientTransport.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/client/WebSocketClientTransport.kt
@@ -26,14 +26,14 @@ import io.ktor.http.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 import io.rsocket.kotlin.transport.ktor.*
+import kotlinx.coroutines.*
 
 public fun WebSocketClientTransport(
     httpClient: HttpClient,
     request: HttpRequestBuilder.() -> Unit,
-): ClientTransport = ClientTransport {
+): ClientTransport = ClientTransport(httpClient.coroutineContext + SupervisorJob(httpClient.coroutineContext[Job])) {
     val session = httpClient.webSocketSession(request)
-    @Suppress("INVISIBLE_MEMBER")
-    WebSocketConnection(session)
+    @Suppress("INVISIBLE_MEMBER") WebSocketConnection(session)
 }
 
 public fun WebSocketClientTransport(

--- a/rsocket-transport-ktor/rsocket-transport-ktor-server/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/server/WebSocketServerTransport.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-server/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/server/WebSocketServerTransport.kt
@@ -29,13 +29,11 @@ internal fun Route.serverTransport(
 ): ServerTransport<Unit> = ServerTransport { acceptor ->
     when (path) {
         null -> webSocket(protocol) {
-            @Suppress("INVISIBLE_MEMBER")
-            val connection = WebSocketConnection(this)
+            val connection = @Suppress("INVISIBLE_MEMBER") WebSocketConnection(this)
             acceptor(connection)
         }
         else -> webSocket(path, protocol) {
-            @Suppress("INVISIBLE_MEMBER")
-            val connection = WebSocketConnection(this)
+            val connection = @Suppress("INVISIBLE_MEMBER") WebSocketConnection(this)
             acceptor(connection)
         }
     }

--- a/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
+++ b/rsocket-transport-ktor/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnection.kt
@@ -22,10 +22,7 @@ import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 
 @TransportApi
-internal class WebSocketConnection(private val session: WebSocketSession) : Connection {
-
-    override val job: Job = session.coroutineContext.job
-
+internal class WebSocketConnection(private val session: WebSocketSession) : Connection, CoroutineScope by session {
     override suspend fun send(packet: ByteReadPacket) {
         session.send(packet.readBytes())
     }

--- a/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/PortProvider.kt
+++ b/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/PortProvider.kt
@@ -1,0 +1,9 @@
+package io.rsocket.kotlin.transport.ktor
+
+import kotlinx.atomicfu.*
+import kotlin.random.*
+
+object PortProvider {
+    private val port = atomic(Random.nextInt(20, 90) * 100)
+    fun next(): Int = port.incrementAndGet()
+}

--- a/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpTransportTest.kt
@@ -16,38 +16,22 @@
 
 package io.rsocket.kotlin.transport.ktor
 
-import io.ktor.network.selector.*
 import io.ktor.util.network.*
 import io.rsocket.kotlin.test.*
-import io.rsocket.kotlin.transport.*
-import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
-import kotlin.random.*
 
-abstract class TcpTransportTest(
-    private val clientSelector: SelectorManager,
-    protected val serverSelector: SelectorManager
-) : TransportTest() {
-    private lateinit var server: Job
-
-    //on Native uses default transport
-    //on JVM uses little different, because of bug in KTOR
-    abstract fun serverTransport(address: NetworkAddress): ServerTransport<Job>
+abstract class TcpTransportTest : TransportTest() {
+    private val testJob = Job()
 
     override suspend fun before() {
-        val address = NetworkAddress("0.0.0.0", port.incrementAndGet())
-        server = SERVER.bind(serverTransport(address), ACCEPTOR)
-        client = CONNECTOR.connect(TcpClientTransport(clientSelector, address))
+        val address = NetworkAddress("0.0.0.0", PortProvider.next())
+        val context = testJob + CoroutineExceptionHandler { c, e -> println("$c -> $e") }
+        SERVER.bindIn(CoroutineScope(context), TcpServerTransport(address, InUseTrackingPool), ACCEPTOR).serverSocket.await()
+        client = CONNECTOR.connect(TcpClientTransport(address, context, InUseTrackingPool))
     }
 
     override suspend fun after() {
         super.after()
-        server.cancelAndJoin()
-        clientSelector.close()
-        serverSelector.close()
-    }
-
-    companion object {
-        private val port = atomic(Random.nextInt(20, 90) * 100)
+        testJob.cancelAndJoin()
     }
 }

--- a/rsocket-transport-ktor/src/jsMain/kotlin/io/rsocket/kotlin/transport/ktor/defaultDispatcher.kt
+++ b/rsocket-transport-ktor/src/jsMain/kotlin/io/rsocket/kotlin/transport/ktor/defaultDispatcher.kt
@@ -1,0 +1,5 @@
+package io.rsocket.kotlin.transport.ktor
+
+import kotlinx.coroutines.*
+
+internal actual val defaultDispatcher: CoroutineDispatcher get() = Dispatchers.Default

--- a/rsocket-transport-ktor/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/defaultDispatcher.kt
+++ b/rsocket-transport-ktor/src/jvmMain/kotlin/io/rsocket/kotlin/transport/ktor/defaultDispatcher.kt
@@ -1,0 +1,5 @@
+package io.rsocket.kotlin.transport.ktor
+
+import kotlinx.coroutines.*
+
+internal actual val defaultDispatcher: CoroutineDispatcher get() = Dispatchers.IO

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/JvmTcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/JvmTcpTransportTest.kt
@@ -16,35 +16,5 @@
 
 package io.rsocket.kotlin.transport.ktor
 
-import io.ktor.network.selector.*
-import io.ktor.network.sockets.*
-import io.ktor.util.network.*
-import io.rsocket.kotlin.Connection
-import io.rsocket.kotlin.transport.*
-import kotlinx.atomicfu.*
-import kotlinx.coroutines.*
-
-class JvmTcpTransportTest : TcpTransportTest(ActorSelectorManager(Dispatchers.IO), ActorSelectorManager(Dispatchers.IO)) {
-    //hack because of https://youtrack.jetbrains.com/issue/KTOR-2881
-    private var serverConnection: Connection? by atomic(null)
-    override fun serverTransport(address: NetworkAddress): ServerTransport<Job> = ServerTransport { accept ->
-        val serverSocket = aSocket(serverSelector).tcp().bind(address)
-        GlobalScope.launch(
-            serverSocket.socketContext + Dispatchers.Unconfined + ignoreExceptionHandler,
-            CoroutineStart.UNDISPATCHED
-        ) {
-            val clientSocket = serverSocket.accept()
-            serverConnection = TcpConnection(clientSocket)
-            accept(serverConnection!!)
-        }
-        serverSocket.socketContext
-    }
-
-    override suspend fun after() {
-        //we need to cancel server connection job manually on JVM
-        serverConnection?.job?.cancelAndJoin()
-        super.after()
-    }
-}
-
-class JvmTcpServerTest : TcpServerTest(ActorSelectorManager(Dispatchers.IO), ActorSelectorManager(Dispatchers.IO))
+class JvmTcpTransportTest : TcpTransportTest()
+class JvmTcpServerTest : TcpServerTest()

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
@@ -29,7 +29,6 @@ import io.rsocket.kotlin.transport.ktor.client.*
 import io.rsocket.kotlin.transport.ktor.server.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
-import kotlin.random.*
 import kotlin.test.*
 import io.ktor.client.engine.cio.CIO as ClientCIO
 import io.ktor.client.features.websocket.WebSockets as ClientWebSockets
@@ -39,7 +38,7 @@ import io.rsocket.kotlin.transport.ktor.client.RSocketSupport as ClientRSocketSu
 import io.rsocket.kotlin.transport.ktor.server.RSocketSupport as ServerRSocketSupport
 
 class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
-    private val port = Random.nextInt(20, 90) * 100
+    private val port = PortProvider.next()
     private val client = HttpClient(ClientCIO) {
         install(ClientWebSockets)
         install(ClientRSocketSupport) {
@@ -69,7 +68,7 @@ class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
                             }
                         }
                     }
-                }.also { responderJob = it.job }
+                }.also { responderJob = it.coroutineContext.job }
             }
         }
     }
@@ -86,7 +85,7 @@ class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
     @Test
     fun testWorks() = test {
         val rSocket = client.rSocket(port = port)
-        val requesterJob = rSocket.job
+        val requesterJob = rSocket.coroutineContext.job
 
         rSocket
             .requestStream(Payload.Empty)

--- a/rsocket-transport-ktor/src/nativeMain/kotlin/io/rsocket/kotlin/transport/ktor/defaultDispatcher.kt
+++ b/rsocket-transport-ktor/src/nativeMain/kotlin/io/rsocket/kotlin/transport/ktor/defaultDispatcher.kt
@@ -1,0 +1,5 @@
+package io.rsocket.kotlin.transport.ktor
+
+import kotlinx.coroutines.*
+
+internal actual val defaultDispatcher: CoroutineDispatcher get() = Dispatchers.Unconfined

--- a/rsocket-transport-ktor/src/nativeTest/kotlin/io/rsocket/kotlin/transport/ktor/NativeTcpTransportTest.kt
+++ b/rsocket-transport-ktor/src/nativeTest/kotlin/io/rsocket/kotlin/transport/ktor/NativeTcpTransportTest.kt
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin
+package io.rsocket.kotlin.transport.ktor
 
-import io.ktor.network.selector.*
-import io.ktor.util.network.*
-import io.rsocket.kotlin.transport.*
-import io.rsocket.kotlin.transport.ktor.*
-import kotlinx.coroutines.*
-
-class NativeTcpTransportTest : TcpTransportTest(SelectorManager(), SelectorManager()) {
-    override fun serverTransport(address: NetworkAddress): ServerTransport<Job> =
-        TcpServerTransport(serverSelector, address)
-}
-
-class NativeTcpServerTest : TcpServerTest(SelectorManager(), SelectorManager())
+class NativeTcpTransportTest : TcpTransportTest()
+class NativeTcpServerTest : TcpServerTest()

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalConnection.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalConnection.kt
@@ -20,15 +20,15 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.*
-import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
+import kotlin.coroutines.*
 
 @OptIn(TransportApi::class)
 internal class LocalConnection(
     private val sender: SendChannel<ByteReadPacket>,
     private val receiver: ReceiveChannel<ByteReadPacket>,
     override val pool: ObjectPool<ChunkBuffer>,
-    override val job: Job
+    override val coroutineContext: CoroutineContext
 ) : Connection {
 
     override suspend fun send(packet: ByteReadPacket) {

--- a/rsocket-transport-local/src/commonTest/kotlin/io/rsocket/kotlin/transport/local/LocalTransportTest.kt
+++ b/rsocket-transport-local/src/commonTest/kotlin/io/rsocket/kotlin/transport/local/LocalTransportTest.kt
@@ -20,14 +20,15 @@ import io.rsocket.kotlin.test.*
 import kotlinx.coroutines.*
 
 class LocalTransportTest : TransportTest() {
-
-    private val testJob: Job = Job()
+    private val testJob = Job()
 
     override suspend fun before() {
-        super.before()
-        val localServer = LocalServer(testJob, InUseTrackingPool)
-        SERVER.bind(localServer, ACCEPTOR)
-        client = CONNECTOR.connect(localServer)
+        val server = SERVER.bindIn(
+            CoroutineScope(testJob + CoroutineExceptionHandler { c, e -> println("$c -> $e") }),
+            LocalServerTransport(InUseTrackingPool),
+            ACCEPTOR
+        )
+        client = CONNECTOR.connect(server)
     }
 
     override suspend fun after() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,11 +41,6 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        jcenter {
-            content {
-                includeModule("org.jetbrains.kotlinx", "kotlinx-nodejs")
-            }
-        }
     }
 }
 
@@ -80,7 +75,8 @@ fun includeExample(name: String) {
     include("examples:$name")
 }
 
-includeExample("nodejs-tcp-transport")
+//TODO ignore for now, as `kotlinx-nodejs` isn't maintained now
+//includeExample("nodejs-tcp-transport")
 includeExample("interactions")
 includeExample("multiplatform-chat")
 


### PR DESCRIPTION
_**NOTE: Depends on #177**_

* fixes #169 
* Reworked how Client/Server transports are implemented
  * let users provide `CoroutineScope` where to launch `Server` in general way for all transports: in that way, users and transports can control both life-cycle and dispatchers for server running code
  * add `CoroutineContext` to `ClientTransport` to specify in which context handling will happen
  * allow users to launch server in specific scope and attach `ClientTransport` to some Job
* `Connection` and `RSocket` now implements `CoroutineScope`
* hacked `Limiter` to work all time even if not efficient (@OlegDokuka will improve this)
* Improve TcpClient and TcpServer transport
  * automatic handling of `SelectorManager` based on provided context: default dispatcher for JVM is IO, if you override it, make sure, that this dispatcher is suitable for blocking tasks, don't use `Default` dispatcher, for TCP
