### PR TITLE
сleanups of close/release inconsistency

### DIFF
--- a/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
+++ b/benchmarks/src/kotlinMain/kotlin/io/rsocket/kotlin/benchmarks/RSocketKotlinBenchmark.kt
@@ -43,15 +43,15 @@ class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
         val server = RSocketServer().bindIn(CoroutineScope(benchJob + Dispatchers.Unconfined), LocalServerTransport()) {
             RSocketRequestHandler {
                 requestResponse {
-                    it.release()
+                    it.close()
                     payloadCopy()
                 }
                 requestStream {
-                    it.release()
+                    it.close()
                     payloadsFlow
                 }
                 requestChannel { init, payloads ->
-                    init.release()
+                    init.close()
                     payloads.flowOn(requestStrategy)
                 }
             }
@@ -74,7 +74,7 @@ class RSocketKotlinBenchmark : RSocketBenchmark<Payload>() {
     )
 
     override fun releasePayload(payload: Payload) {
-        payload.release()
+        payload.close()
     }
 
     override suspend fun doRequestResponse(): Payload = client.requestResponse(payloadCopy())

--- a/examples/multiplatform-chat/src/clientMain/kotlin/ChatApi.kt
+++ b/examples/multiplatform-chat/src/clientMain/kotlin/ChatApi.kt
@@ -34,6 +34,6 @@ actual class ChatApi(private val rSocket: RSocket, private val proto: ProtoBuf) 
     actual suspend fun delete(id: Int) {
         rSocket.requestResponse(
             proto.encodeToPayload(route = "chats.delete", DeleteChat(id))
-        ).release()
+        ).close()
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocket.kt
@@ -24,27 +24,27 @@ import kotlinx.coroutines.flow.*
 public interface RSocket : CoroutineScope {
 
     public suspend fun metadataPush(metadata: ByteReadPacket) {
-        metadata.release()
+        metadata.close()
         notImplemented("Metadata Push")
     }
 
     public suspend fun fireAndForget(payload: Payload) {
-        payload.release()
+        payload.close()
         notImplemented("Fire and Forget")
     }
 
     public suspend fun requestResponse(payload: Payload): Payload {
-        payload.release()
+        payload.close()
         notImplemented("Request Response")
     }
 
     public fun requestStream(payload: Payload): Flow<Payload> {
-        payload.release()
+        payload.close()
         notImplemented("Request Stream")
     }
 
     public fun requestChannel(initPayload: Payload, payloads: Flow<Payload>): Flow<Payload> {
-        initPayload.release()
+        initPayload.close()
         notImplemented("Request Channel")
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -73,8 +73,8 @@ public class RSocketConnector internal constructor(
             connection.sendFrame(setupFrame)
             return requester
         } catch (cause: Throwable) {
-            connectionConfig.setupPayload.release()
-            setupFrame.release()
+            connectionConfig.setupPayload.close()
+            setupFrame.close()
             connection.cancel("Connection establishment failed", cause)
             throw cause
         }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -113,7 +113,7 @@ public class RSocketConnectorBuilder internal constructor() {
 
     private companion object {
         private val defaultAcceptor: ConnectionAcceptor = ConnectionAcceptor {
-            config.setupPayload.release()
+            config.setupPayload.close()
             EmptyRSocket()
         }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/CancelFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/CancelFrame.kt
@@ -24,7 +24,7 @@ internal class CancelFrame(
     override val type: FrameType get() = FrameType.Cancel
     override val flags: Int get() = 0
 
-    override fun release(): Unit = Unit
+    override fun close(): Unit = Unit
 
     override fun BytePacketBuilder.writeSelf(): Unit = Unit
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
@@ -27,7 +27,7 @@ internal class ErrorFrame(
     override val flags: Int get() = 0
     val errorCode get() = (throwable as? RSocketError)?.errorCode ?: ErrorCode.ApplicationError
 
-    override fun release(): Unit = Unit
+    override fun close(): Unit = Unit
 
     override fun BytePacketBuilder.writeSelf() {
         writeInt(errorCode)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
@@ -30,8 +30,8 @@ internal class ExtensionFrame(
     override val type: FrameType get() = FrameType.Extension
     override val flags: Int get() = if (payload.metadata != null) Flags.Metadata else 0
 
-    override fun release() {
-        payload.release()
+    override fun close() {
+        payload.close()
     }
 
     override fun BytePacketBuilder.writeSelf() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
@@ -29,8 +29,6 @@ public sealed class Frame : Closeable {
     public abstract val streamId: Int
     public abstract val flags: Int
 
-    internal abstract fun release()
-
     protected abstract fun BytePacketBuilder.writeSelf()
     protected abstract fun StringBuilder.appendFlags()
     protected abstract fun StringBuilder.appendSelf()
@@ -53,10 +51,6 @@ public sealed class Frame : Closeable {
     protected fun StringBuilder.appendFlag(flag: Char, value: Boolean) {
         append(flag)
         if (value) append(1) else append(0)
-    }
-
-    override fun close() {
-        release()
     }
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
@@ -32,8 +32,8 @@ internal class KeepAliveFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = if (respond) RespondFlag else 0
 
-    override fun release() {
-        data.release()
+    override fun close() {
+        data.close()
     }
 
     override fun BytePacketBuilder.writeSelf() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
@@ -30,8 +30,8 @@ internal class LeaseFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = if (metadata != null) Flags.Metadata else 0
 
-    override fun release() {
-        metadata?.release()
+    override fun close() {
+        metadata?.close()
     }
 
     override fun BytePacketBuilder.writeSelf() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
@@ -28,8 +28,8 @@ internal class MetadataPushFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = Flags.Metadata
 
-    override fun release() {
-        metadata.release()
+    override fun close() {
+        metadata.close()
     }
 
     override fun BytePacketBuilder.writeSelf() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
@@ -43,8 +43,8 @@ internal class RequestFrame(
             return flags
         }
 
-    override fun release() {
-        payload.release()
+    override fun close() {
+        payload.close()
     }
 
     override fun BytePacketBuilder.writeSelf() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
@@ -25,7 +25,7 @@ internal class RequestNFrame(
     override val type: FrameType get() = FrameType.RequestN
     override val flags: Int get() = 0
 
-    override fun release(): Unit = Unit
+    override fun close(): Unit = Unit
 
     override fun BytePacketBuilder.writeSelf() {
         writeInt(requestN)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
@@ -31,7 +31,7 @@ internal class ResumeFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = 0
 
-    override fun release(): Unit = Unit
+    override fun close(): Unit = Unit
 
     override fun BytePacketBuilder.writeSelf() {
         writeVersion(version)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
@@ -25,7 +25,7 @@ internal class ResumeOkFrame(
     override val streamId: Int get() = 0
     override val flags: Int get() = 0
 
-    override fun release(): Unit = Unit
+    override fun close(): Unit = Unit
 
     override fun BytePacketBuilder.writeSelf() {
         writeLong(lastReceivedClientPosition)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
@@ -45,9 +45,9 @@ internal class SetupFrame(
             return flags
         }
 
-    override fun release() {
-        resumeToken?.release()
-        payload.release()
+    override fun close() {
+        resumeToken?.close()
+        payload.close()
     }
 
     override fun BytePacketBuilder.writeSelf() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/packet.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/packet.kt
@@ -26,7 +26,7 @@ internal inline fun buildPacket(pool: ObjectPool<ChunkBuffer>, block: BytePacket
         block(builder)
         return builder.build()
     } catch (t: Throwable) {
-        builder.release()
+        builder.close()
         throw t
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
@@ -41,7 +41,7 @@ internal suspend inline fun connect(
     requestJob.invokeOnCompletion {
         prioritizer.close(it)
         streamsStorage.cleanup(it)
-        connectionConfig.setupPayload.release()
+        connectionConfig.setupPayload.close()
     }
 
     val requester = interceptors.wrapRequester(
@@ -76,8 +76,8 @@ internal suspend inline fun connect(
                     is MetadataPushFrame -> responder.handleMetadataPush(frame.metadata)
                     is ErrorFrame        -> connection.cancel("Error frame received on 0 stream", frame.throwable)
                     is KeepAliveFrame    -> keepAliveHandler.mark(frame)
-                    is LeaseFrame        -> frame.release().also { error("lease isn't implemented") }
-                    else                 -> frame.release()
+                    is LeaseFrame        -> frame.close().also { error("lease isn't implemented") }
+                    else                 -> frame.close()
                 }
                 else -> streamsStorage.handleFrame(frame, responder)
             }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
@@ -51,7 +51,7 @@ internal class RSocketRequester(
         try {
             sender.sendRequestPayload(FrameType.RequestFnF, id, payload)
         } catch (cause: Throwable) {
-            payload.release()
+            payload.close()
             if (isActive) sender.sendCancel(id) //if cancelled during fragmentation
             throw cause
         }
@@ -128,7 +128,7 @@ internal class RSocketRequester(
             onReceiveComplete()
             return result
         } catch (cause: Throwable) {
-            payload.release()
+            payload.close()
             val isCancelled = onReceiveCancelled(cause)
             if (isActive && isCancelled) sender.sendCancel(id)
             throw cause

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketResponder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketResponder.kt
@@ -78,7 +78,7 @@ internal class RSocketResponder(
             if (currentCoroutineContext().isActive && isFailed) sender.sendError(id, cause)
             throw cause
         } finally {
-            payload.release()
+            payload.close()
         }
     }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/FrameHandler.kt
@@ -23,7 +23,7 @@ import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 
-internal abstract class FrameHandler(pool: ObjectPool<ChunkBuffer>) {
+internal abstract class FrameHandler(pool: ObjectPool<ChunkBuffer>) : Closeable {
     private val data = BytePacketBuilder(0, pool)
     private val metadata = BytePacketBuilder(0, pool)
     protected abstract var hasMetadata: Boolean
@@ -57,9 +57,9 @@ internal abstract class FrameHandler(pool: ObjectPool<ChunkBuffer>) {
 
     abstract fun cleanup(cause: Throwable?)
 
-    fun release() {
-        data.release()
-        metadata.release()
+    override fun close() {
+        data.close()
+        metadata.close()
     }
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
@@ -32,7 +32,7 @@ public fun CompositeMetadata(entries: List<Metadata>): CompositeMetadata =
     DefaultCompositeMetadata(entries.map(CompositeMetadata::Entry))
 
 @ExperimentalMetadataApi
-public interface CompositeMetadata : Metadata {
+public sealed interface CompositeMetadata : Metadata {
     public val entries: List<Entry>
     override val mimeType: MimeType get() = Reader.mimeType
 
@@ -42,6 +42,10 @@ public interface CompositeMetadata : Metadata {
             writeLength(it.content.remaining.toInt()) //write metadata length
             writePacket(it.content) //write metadata content
         }
+    }
+
+    override fun close() {
+        entries.forEach { it.content.close() }
     }
 
     public class Entry(public val mimeType: MimeType, public val content: ByteReadPacket) {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
@@ -29,7 +29,7 @@ public fun CompositeMetadata.Entry.hasMimeTypeOf(reader: MetadataReader<*>): Boo
 public fun <M : Metadata> CompositeMetadata.Entry.read(reader: MetadataReader<M>, pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool): M {
     if (mimeType == reader.mimeType) return content.read(reader, pool)
 
-    content.release()
+    content.close()
     error("Expected mimeType '${reader.mimeType}' but was '$mimeType'")
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
@@ -25,7 +25,7 @@ import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.payload.*
 
 @ExperimentalMetadataApi
-public interface Metadata {
+public interface Metadata : Closeable {
     public val mimeType: MimeType
     public fun BytePacketBuilder.writeSelf()
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
@@ -37,6 +37,8 @@ public class PerStreamAcceptableDataMimeTypesMetadata(public val types: List<Mim
         }
     }
 
+    override fun close(): Unit = Unit
+
     public companion object Reader : MetadataReader<PerStreamAcceptableDataMimeTypesMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAcceptMimeTypes
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): PerStreamAcceptableDataMimeTypesMetadata {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
@@ -31,6 +31,8 @@ public class PerStreamDataMimeTypeMetadata(public val type: MimeType) : Metadata
         writeMimeType(type)
     }
 
+    override fun close(): Unit = Unit
+
     public companion object Reader : MetadataReader<PerStreamDataMimeTypeMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketMimeType
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): PerStreamDataMimeTypeMetadata =

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
@@ -32,6 +32,10 @@ public class RawMetadata(
         writePacket(content)
     }
 
+    override fun close() {
+        content.close()
+    }
+
     private class Reader(override val mimeType: MimeType) : MetadataReader<RawMetadata> {
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): RawMetadata = RawMetadata(mimeType, readPacket(pool))
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
@@ -43,6 +43,8 @@ public class RoutingMetadata(public val tags: List<String>) : Metadata {
         }
     }
 
+    override fun close(): Unit = Unit
+
     public companion object Reader : MetadataReader<RoutingMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketRouting
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): RoutingMetadata {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
@@ -67,6 +67,8 @@ public class ZipkinTracingMetadata internal constructor(
         if (hasParentSpanId) writeLong(parentSpanId)
     }
 
+    override fun close(): Unit = Unit
+
     public companion object Reader : MetadataReader<ZipkinTracingMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketTracingZipkin
         override fun ByteReadPacket.read(pool: ObjectPool<ChunkBuffer>): ZipkinTracingMetadata {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
@@ -25,7 +25,7 @@ import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.metadata.*
 
 @ExperimentalMetadataApi
-public interface AuthMetadata : Metadata {
+public sealed interface AuthMetadata : Metadata {
     public val type: AuthType
     public fun BytePacketBuilder.writeContent()
 
@@ -38,7 +38,7 @@ public interface AuthMetadata : Metadata {
 }
 
 @ExperimentalMetadataApi
-public interface AuthMetadataReader<AM : AuthMetadata> : MetadataReader<AM> {
+public sealed interface AuthMetadataReader<AM : AuthMetadata> : MetadataReader<AM> {
     public fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): AM
 
     override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAuthentication

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
@@ -30,6 +30,8 @@ public class BearerAuthMetadata(
         writeText(token)
     }
 
+    override fun close(): Unit = Unit
+
     public companion object Reader : AuthMetadataReader<BearerAuthMetadata> {
         override fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): BearerAuthMetadata {
             require(type == WellKnowAuthType.Bearer) { "Metadata auth type should be 'bearer'" }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
@@ -32,6 +32,10 @@ public class RawAuthMetadata(
         writePacket(content)
     }
 
+    override fun close() {
+        content.close()
+    }
+
     public companion object Reader : AuthMetadataReader<RawAuthMetadata> {
         override fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): RawAuthMetadata {
             val content = readPacket(pool)
@@ -46,7 +50,7 @@ public fun RawAuthMetadata.hasAuthTypeOf(reader: AuthMetadataReader<*>): Boolean
 @ExperimentalMetadataApi
 public fun <AM : AuthMetadata> RawAuthMetadata.read(reader: AuthMetadataReader<AM>, pool: ObjectPool<ChunkBuffer> = ChunkBuffer.Pool): AM {
     return readOrNull(reader, pool) ?: run {
-        content.release()
+        content.close()
         error("Expected auth type '${reader.mimeType}' but was '$mimeType'")
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
@@ -32,12 +32,15 @@ public class SimpleAuthMetadata(
     }
 
     override val type: AuthType get() = WellKnowAuthType.Simple
+
     override fun BytePacketBuilder.writeContent() {
         val length = username.encodeToByteArray()
         writeShort(length.size.toShort())
         writeText(username)
         writeText(password)
     }
+
+    override fun close(): Unit = Unit
 
     public companion object Reader : AuthMetadataReader<SimpleAuthMetadata> {
         override fun ByteReadPacket.readContent(type: AuthType, pool: ObjectPool<ChunkBuffer>): SimpleAuthMetadata {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/Payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/payload/Payload.kt
@@ -26,13 +26,9 @@ public sealed interface Payload : Closeable {
 
     public fun copy(): Payload = DefaultPayload(data.copy(), metadata?.copy())
 
-    public fun release() {
-        data.release()
-        metadata?.release()
-    }
-
     override fun close() {
-        release()
+        data.close()
+        metadata?.close()
     }
 
     public companion object {

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/RSocketRequesterTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/internal/RSocketRequesterTest.kt
@@ -346,7 +346,7 @@ class RSocketRequesterTest : TestWithConnection(), TestWithLeakCheck {
                 val streamId = frame.streamId
                 assertTrue(frame is RequestFrame)
                 assertEquals(FrameType.RequestChannel, frame.type)
-                frame.release()
+                frame.close()
                 connection.sendToReceiver(CancelFrame(streamId), CompletePayloadFrame(streamId))
             }
             response.join()

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataTest.kt
@@ -89,7 +89,7 @@ class CompositeMetadataTest : TestWithLeakCheck {
         assertTrue(WellKnownMimeType.ApplicationAvro in decoded)
         assertTrue(WellKnownMimeType.MessageRSocketRouting !in decoded)
 
-        decoded.entries.forEach { it.content.release() }
+        decoded.entries.forEach { it.content.close() }
     }
 
     @Test

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/payload/PayloadBuilderTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/payload/PayloadBuilderTest.kt
@@ -37,8 +37,8 @@ class PayloadBuilderTest : TestWithLeakCheck {
     }
 
     @Test
-    fun payloadRelease() {
-        Payload(packet("data"), packet("metadata")).release()
+    fun payloadclose() {
+        Payload(packet("data"), packet("metadata")).close()
     }
 
     @Test

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/Packets.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/Packets.kt
@@ -43,7 +43,7 @@ private inline fun buildPacket(pool: ObjectPool<ChunkBuffer>, block: BytePacketB
         block(builder)
         return builder.build()
     } catch (t: Throwable) {
-        builder.release()
+        builder.close()
         throw t
     }
 }

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TestRSocket.kt
@@ -26,24 +26,24 @@ import kotlin.coroutines.*
 class TestRSocket : RSocket {
     override val coroutineContext: CoroutineContext = Job()
 
-    override suspend fun metadataPush(metadata: ByteReadPacket): Unit = metadata.release()
+    override suspend fun metadataPush(metadata: ByteReadPacket): Unit = metadata.close()
 
-    override suspend fun fireAndForget(payload: Payload): Unit = payload.release()
+    override suspend fun fireAndForget(payload: Payload): Unit = payload.close()
 
     override suspend fun requestResponse(payload: Payload): Payload {
-        payload.release()
+        payload.close()
         return Payload(packet(data), packet(metadata))
     }
 
     override fun requestStream(payload: Payload): Flow<Payload> = flow {
-        payload.release()
+        payload.close()
         repeat(10000) {
             emitOrClose(Payload(packet(data), packet(metadata)))
         }
     }
 
     override fun requestChannel(initPayload: Payload, payloads: Flow<Payload>): Flow<Payload> = flow {
-        initPayload.release()
+        initPayload.close()
         payloads.collect { emitOrClose(it) }
     }
 

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/TransportTest.kt
@@ -63,7 +63,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
 
     @Test
     fun requestChannel1() = test(Duration.seconds(10)) {
-        val list = client.requestChannel(payload(0), flowOf(payload(0))).onEach { it.release() }.toList()
+        val list = client.requestChannel(payload(0), flowOf(payload(0))).onEach { it.close() }.toList()
         assertEquals(1, list.size)
     }
 
@@ -72,7 +72,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
         val request = flow {
             repeat(3) { emit(payload(it)) }
         }
-        val list = client.requestChannel(payload(0), request).flowOn(PrefetchStrategy(3, 0)).onEach { it.release() }.toList()
+        val list = client.requestChannel(payload(0), request).flowOn(PrefetchStrategy(3, 0)).onEach { it.close() }.toList()
         assertEquals(3, list.size)
     }
 
@@ -84,7 +84,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
         val list =
             client.requestChannel(LARGE_PAYLOAD, request)
                 .flowOn(PrefetchStrategy(Int.MAX_VALUE, 0))
-                .onEach { it.release() }
+                .onEach { it.close() }
                 .toList()
         assertEquals(200, list.size)
     }
@@ -106,7 +106,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
         val request = flow {
             repeat(200_000) { emit(payload(it)) }
         }
-        val list = client.requestChannel(payload(0), request).flowOn(PrefetchStrategy(10000, 0)).onEach { it.release() }.toList()
+        val list = client.requestChannel(payload(0), request).flowOn(PrefetchStrategy(10000, 0)).onEach { it.close() }.toList()
         assertEquals(200_000, list.size)
     }
 
@@ -119,7 +119,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
         }
         (0..16).map {
             async(Dispatchers.Default) {
-                val list = client.requestChannel(payload(0), request).onEach { it.release() }.toList()
+                val list = client.requestChannel(payload(0), request).onEach { it.close() }.toList()
                 assertEquals(256, list.size)
             }
         }.awaitAll()
@@ -134,7 +134,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
         }
         (0..256).map {
             async(Dispatchers.Default) {
-                val list = client.requestChannel(payload(0), request).onEach { it.release() }.toList()
+                val list = client.requestChannel(payload(0), request).onEach { it.close() }.toList()
                 assertEquals(512, list.size)
             }
         }.awaitAll()
@@ -174,7 +174,7 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
 
     @Test
     fun largePayloadRequestResponse100() = test {
-        (1..100).map { async { client.requestResponse(LARGE_PAYLOAD) } }.awaitAll().onEach { it.release() }
+        (1..100).map { async { client.requestResponse(LARGE_PAYLOAD) } }.awaitAll().onEach { it.close() }
     }
 
     @Test

--- a/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTest.kt
+++ b/rsocket-transport-ktor/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/TcpServerTest.kt
@@ -53,7 +53,7 @@ abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
         }.connect(clientTransport)
 
         val client1 = newClient("ok")
-        client1.requestResponse(payload("ok")).release()
+        client1.requestResponse(payload("ok")).close()
 
         val client2 = newClient("not ok")
         assertFails {
@@ -62,8 +62,8 @@ abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
 
         val client3 = newClient("ok")
 
-        client3.requestResponse(payload("ok")).release()
-        client1.requestResponse(payload("ok")).release()
+        client3.requestResponse(payload("ok")).close()
+        client1.requestResponse(payload("ok")).close()
 
         assertTrue(client1.isActive)
         assertFalse(client2.isActive)
@@ -90,18 +90,18 @@ abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
 
         val client1 = newClient()
 
-        client1.requestResponse(payload("1")).release()
+        client1.requestResponse(payload("1")).close()
 
         val client2 = newClient()
 
-        client2.requestResponse(payload("1")).release()
+        client2.requestResponse(payload("1")).close()
 
         handlers[1].coroutineContext.job.apply {
             cancel("FAILED")
             join()
         }
 
-        client1.requestResponse(payload("1")).release()
+        client1.requestResponse(payload("1")).close()
 
         assertFails {
             client2.requestResponse(payload("1"))
@@ -109,9 +109,9 @@ abstract class TcpServerTest : SuspendTest, TestWithLeakCheck {
 
         val client3 = newClient()
 
-        client3.requestResponse(payload("1")).release()
+        client3.requestResponse(payload("1")).close()
 
-        client1.requestResponse(payload("1")).release()
+        client1.requestResponse(payload("1")).close()
 
         assertTrue(client1.isActive)
         assertFalse(client2.isActive)

--- a/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
+++ b/rsocket-transport-ktor/src/jvmTest/kotlin/io/rsocket/kotlin/transport/ktor/WebSocketConnectionTest.kt
@@ -59,7 +59,7 @@ class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
             rSocket {
                 RSocketRequestHandler {
                     requestStream {
-                        it.release()
+                        it.close()
                         flow {
                             var i = 0
                             while (true) {
@@ -90,7 +90,7 @@ class WebSocketConnectionTest : SuspendTest, TestWithLeakCheck {
         rSocket
             .requestStream(Payload.Empty)
             .take(2)
-            .onEach { delay(100); it.release() }
+            .onEach { delay(100); it.close() }
             .collect()
 
         assertTrue(requesterJob.isActive)


### PR DESCRIPTION
_**NOTE: Depends on #178**_


* Metadata, PayloadBuilder and CompositeMetadataBuilder implements Closeable
* remove Frame.release and Payload.release (use close instead)
* use close instead of release everywhere
* use sealed in composite and auth metadata