### PR TITLE
Local reusable workflows

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   test:
-    uses: rsocket/rsocket-kotlin/.github/workflows/run-tests.yml@master
+    uses: ./.github/workflows/run-tests.yml
   publish:
     needs: [ test ]
-    uses: rsocket/rsocket-kotlin/.github/workflows/publish-snapshot.yml@master
+    uses: ./.github/workflows/publish-snapshot.yml
     with:
       add-branch-suffix: true

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   test:
-    uses: rsocket/rsocket-kotlin/.github/workflows/run-tests.yml@master
+    uses: ./.github/workflows/run-tests.yml
   publish:
     needs: [ test ]
-    uses: rsocket/rsocket-kotlin/.github/workflows/publish-snapshot.yml@master
+    uses: ./.github/workflows/publish-snapshot.yml
     with:
       add-branch-suffix: false

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   test:
-    uses: rsocket/rsocket-kotlin/.github/workflows/run-tests.yml@master
+    uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    uses: rsocket/rsocket-kotlin/.github/workflows/run-tests.yml@master
+    uses: ./.github/workflows/run-tests.yml
   publish:
     needs: [ test ]
     runs-on: macos-11

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,8 +6,12 @@ env:
 
 jobs:
   jvm-test:
-    name: Run JVM tests
+    name: Run JVM(${{ matrix.target }}) tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ '', '11', '17' ]
     steps:
       - uses: actions/checkout@v2
       - run: echo "KONAN_DATA_DIR=${HOME}/.gradle/konan" >> $GITHUB_ENV
@@ -16,9 +20,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            jvmTest
-            jvm11Test
-            jvm17Test
+            jvm${{ matrix.target }}Test
             --scan
             --info
             --continue
@@ -36,8 +38,12 @@ jobs:
           retention-days: 1
 
   js-test:
-    name: Run JS tests
+    name: Run JS(${{ matrix.target }}) tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ Ir, Legacy ]
     steps:
       - uses: actions/checkout@v2
       - run: echo "KONAN_DATA_DIR=${HOME}/.gradle/konan" >> $GITHUB_ENV
@@ -46,10 +52,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            jsIrNodeTest
-            jsIrBrowserTest
-            jsLegacyNodeTest
-            jsLegacyBrowserTest
+            js${{ matrix.target }}NodeTest
+            js${{ matrix.target }}BrowserTest
             --scan
             --info
             --continue


### PR DESCRIPTION
* Use local reusable workflows: https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/
  * helps to experiment with workflows in forks
* split JVM tests per java version per job
  * soon, with implementation of Netty transports, JVM tests for all 3 java versions will be too long
* split JS tests per IR/Legacy per job
  * legacy JS target has some bugs in compilator, and as so, JS IR tests can success, but Legacy fail
  * it will help to understand faster about the root cause of failure