### PR TITLE
compatibility with K2 compiler

### DIFF
--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Annotations.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Annotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package io.rsocket.kotlin
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,
-    message = "This is an API which is used to implement transport for RSocket, such as WS or TCP. " +
-            "This API can change in future in non backwards-compatible manner."
+    message = "This is an API which is used to implement transport for RSocket, such as WS or TCP. This API can change in future in non backwards-compatible manner."
 )
 public annotation class TransportApi
 

--- a/rsocket-transport-ktor/rsocket-transport-ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpConnection.kt
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpConnection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ internal class TcpConnection(
 ) : Connection {
     private val socketConnection = socket.connection()
 
-    private val sendChannel = @Suppress("INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
-    private val receiveChannel = @Suppress("INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
+    private val sendChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
+    private val receiveChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
 
     init {
         launch {
@@ -48,7 +48,7 @@ internal class TcpConnection(
                     val length = packet.remaining.toInt()
                     try {
                         writePacket {
-                            @Suppress("INVISIBLE_MEMBER") writeLength(length)
+                            @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") writeLength(length)
                             writePacket(packet)
                         }
                         flush()
@@ -62,7 +62,7 @@ internal class TcpConnection(
         launch {
             socketConnection.input.apply {
                 while (isActive) {
-                    val length = @Suppress("INVISIBLE_MEMBER") readPacket(3).readLength()
+                    val length = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") readPacket(3).readLength()
                     val packet = readPacket(length)
                     try {
                         receiveChannel.send(packet)
@@ -74,8 +74,8 @@ internal class TcpConnection(
             }
         }
         coroutineContext.job.invokeOnCompletion {
-            @Suppress("INVISIBLE_MEMBER") sendChannel.fullClose(it)
-            @Suppress("INVISIBLE_MEMBER") receiveChannel.fullClose(it)
+            @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") sendChannel.fullClose(it)
+            @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") receiveChannel.fullClose(it)
             socketConnection.input.cancel(it)
             socketConnection.output.close(it)
             socketConnection.socket.close()

--- a/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transport-local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,12 +49,12 @@ public class LocalServer internal constructor(
     override val coroutineContext: CoroutineContext
 ) : ClientTransport {
     override suspend fun connect(): Connection {
-        val clientChannel = @Suppress("INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
-        val serverChannel = @Suppress("INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
+        val clientChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
+        val serverChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
         val connectionJob = Job(coroutineContext[Job])
         connectionJob.invokeOnCompletion {
-            @Suppress("INVISIBLE_MEMBER") clientChannel.fullClose(it)
-            @Suppress("INVISIBLE_MEMBER") serverChannel.fullClose(it)
+            @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") clientChannel.fullClose(it)
+            @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") serverChannel.fullClose(it)
         }
         val connectionContext = coroutineContext + connectionJob
         val clientConnection = LocalConnection(

--- a/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/FrameWithLengthAssembler.kt
+++ b/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/FrameWithLengthAssembler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
 
 internal fun ByteReadPacket.withLength(): ByteReadPacket = buildPacket {
-    @Suppress("INVISIBLE_MEMBER") writeLength(this@withLength.remaining.toInt())
+    @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") writeLength(this@withLength.remaining.toInt())
     writePacket(this@withLength)
 }
 
@@ -36,7 +36,7 @@ internal class FrameWithLengthAssembler(private val onFrame: (frame: ByteReadPac
         while (true) when {
             expectedFrameLength == 0 && packetBuilder.size < 3 -> return // no length
             expectedFrameLength == 0                           -> withTemp { // has length
-                expectedFrameLength = @Suppress("INVISIBLE_MEMBER") it.readLength()
+                expectedFrameLength = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") it.readLength()
                 if (it.remaining >= expectedFrameLength) build(it) // if has length and frame
             }
             packetBuilder.size < expectedFrameLength           -> return // not enough bytes to read frame

--- a/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpConnection.kt
+++ b/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpConnection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ internal class TcpConnection(
     private val socket: Socket
 ) : Connection {
 
-    private val sendChannel = @Suppress("INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
-    private val receiveChannel = @Suppress("INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
+    private val sendChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
+    private val receiveChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
 
     init {
         launch {


### PR DESCRIPTION
### Motivation:

This is mostly pro-active PR to support compilation with Kotlin K2 compiler.
Tested with Kotlin version 1.9.0-Beta-104.
Changes don't affect old K1 compiler, so it's safe.