### PR TITLE
drop JS legacy and deprecated native targets

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,8 +37,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            jsIrTest
-            jsLegacyTest
+            jsNodeTest
+            jsBrowserTest
             --scan
             --info
             --continue

--- a/buildSrc/src/main/kotlin/targetsNative.kt
+++ b/buildSrc/src/main/kotlin/targetsNative.kt
@@ -59,9 +59,9 @@ fun KotlinMultiplatformExtension.configureNative(
 
 private fun KotlinMultiplatformExtension.darwinTargets(): List<KotlinNativeTarget> {
     val macosTargets = listOf(macosX64(), macosArm64())
-    val iosTargets = listOf(iosArm32(), iosArm64(), iosX64(), iosSimulatorArm64())
+    val iosTargets = listOf(iosArm64(), iosX64(), iosSimulatorArm64())
     val tvosTargets = listOf(tvosArm64(), tvosX64(), tvosSimulatorArm64())
-    val watchosTargets = listOf(watchosArm32(), watchosArm64(), watchosX86(), watchosX64(), watchosSimulatorArm64())
+    val watchosTargets = listOf(watchosArm32(), watchosArm64(), watchosX64(), watchosSimulatorArm64())
     return macosTargets + iosTargets + tvosTargets + watchosTargets
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 group=io.rsocket.kotlin
 version=0.16.0-SNAPSHOT
 #Kotlin
-kotlin.js.compiler=both
+kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.binary.memoryModel=experimental


### PR DESCRIPTION
### Motivation:

* Kotlin JS Legacy compiler was deprecated in Kotlin 1.8.0 - https://kotlinlang.org/docs/js-overview.html#kotlin-js-ir-compiler
* iosArm32 and watchosX86 were deprecated in Kotlin 1.8.20 - https://kotlinlang.org/docs/native-target-support.html#deprecated-targets
* Both will be removed/errored in Kotlin 1.9.0 or 1.9.20

fixes #230