### PR TITLE
gradle configuration cache compatibility

### DIFF
--- a/gradle/plugins/build-logic/src/main/kotlin/rsocket.multiplatform.gradle.kts
+++ b/gradle/plugins/build-logic/src/main/kotlin/rsocket.multiplatform.gradle.kts
@@ -45,5 +45,5 @@ kotlin {
 
 val buildParameters = the<buildparameters.BuildParametersExtension>()
 
-tasks.matching { it.name.endsWith("test", ignoreCase = true) }.configureEach { onlyIf { !buildParameters.skip.test } }
-tasks.matching { it.name.startsWith("link", ignoreCase = true) }.configureEach { onlyIf { !buildParameters.skip.link } }
+if (buildParameters.skip.test) tasks.matching { it.name.endsWith("test", ignoreCase = true) }.configureEach { onlyIf { false } }
+if (buildParameters.skip.link) tasks.matching { it.name.startsWith("link", ignoreCase = true) }.configureEach { onlyIf { false } }


### PR DESCRIPTION
### Motivation:

Upcoming kotlin gradle plugin (likely 1.9.20) will have support for Gradle Configuration Cache in multiplatform projects.
Fix is needed for proper configuration cache support, this is the only issue from project side