### PR TITLE
introduce new module `rsocket-internal-io`

### DIFF
--- a/rsocket-core/build.gradle.kts
+++ b/rsocket-core/build.gradle.kts
@@ -24,6 +24,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.rsocketInternalIo)
+
                 api(libs.kotlinx.coroutines.core)
                 api(libs.ktor.io)
             }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,17 @@ package io.rsocket.kotlin.frame.io
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 
 internal fun ByteReadPacket.readMetadata(pool: ObjectPool<ChunkBuffer>): ByteReadPacket {
-    val length = readLength()
+    val length = readInt24()
     return readPacket(pool, length)
 }
 
 internal fun BytePacketBuilder.writeMetadata(metadata: ByteReadPacket?) {
     metadata?.let {
-        writeLength(it.remaining.toInt())
+        writeInt24(it.remaining.toInt())
         writePacket(it)
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/CloseOperations.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/CloseOperations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,17 +28,6 @@ internal inline fun <T : Closeable, R> T.closeOnError(block: (T) -> R): R {
     }
 }
 
-private val onUndeliveredCloseable: (Closeable) -> Unit = Closeable::close
-
-@Suppress("FunctionName")
-internal fun <E : Closeable> SafeChannel(capacity: Int): Channel<E> =
-    Channel(capacity, onUndeliveredElement = onUndeliveredCloseable)
-
 internal fun <E : Closeable> SendChannel<E>.safeTrySend(element: E) {
     trySend(element).onFailure { element.close() }
-}
-
-internal fun Channel<out Closeable>.fullClose(cause: Throwable?) {
-    close(cause) // close channel to provide right cause
-    cancel() // force call of onUndeliveredElement to release buffered elements
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Prioritizer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Prioritizer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.rsocket.kotlin.internal
 
 import io.rsocket.kotlin.frame.*
+import io.rsocket.kotlin.internal.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.selects.*
@@ -24,8 +25,8 @@ import kotlinx.coroutines.selects.*
 private val selectFrame: suspend (Frame) -> Frame = { it }
 
 internal class Prioritizer {
-    private val priorityChannel = SafeChannel<Frame>(Channel.UNLIMITED)
-    private val commonChannel = SafeChannel<Frame>(Channel.UNLIMITED)
+    private val priorityChannel = channelForCloseable<Frame>(Channel.UNLIMITED)
+    private val commonChannel = channelForCloseable<Frame>(Channel.UNLIMITED)
 
     suspend fun send(frame: Frame) {
         currentCoroutineContext().ensureActive()
@@ -43,7 +44,7 @@ internal class Prioritizer {
     }
 
     fun close(error: Throwable?) {
-        priorityChannel.fullClose(error)
-        commonChannel.fullClose(error)
+        priorityChannel.cancelWithCause(error)
+        commonChannel.cancelWithCause(error)
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/RSocketRequester.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.internal.handler.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
@@ -77,7 +78,7 @@ internal class RSocketRequester(
 
         val id = streamsStorage.nextId()
 
-        val channel = SafeChannel<Payload>(Channel.UNLIMITED)
+        val channel = channelForCloseable<Payload>(Channel.UNLIMITED)
         val handler = RequesterRequestStreamFrameHandler(id, streamsStorage, channel, pool)
         streamsStorage.save(id, handler)
 
@@ -93,7 +94,7 @@ internal class RSocketRequester(
 
             val id = streamsStorage.nextId()
 
-            val channel = SafeChannel<Payload>(Channel.UNLIMITED)
+            val channel = channelForCloseable<Payload>(Channel.UNLIMITED)
             val limiter = Limiter(0)
             val payloadsJob = Job(this@RSocketRequester.coroutineContext.job)
             val handler = RequesterRequestChannelFrameHandler(id, streamsStorage, limiter, payloadsJob, channel, pool)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestChannelFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestChannelFrameHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.internal.handler
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
@@ -42,7 +43,7 @@ internal class RequesterRequestChannelFrameHandler(
 
     override fun handleError(cause: Throwable) {
         streamsStorage.remove(id)
-        channel.fullClose(cause)
+        channel.cancelWithCause(cause)
         sender.cancel("Request failed", cause)
     }
 
@@ -55,7 +56,7 @@ internal class RequesterRequestChannelFrameHandler(
     }
 
     override fun cleanup(cause: Throwable?) {
-        channel.fullClose(cause)
+        channel.cancelWithCause(cause)
         sender.cancel("Connection closed", cause)
     }
 
@@ -78,7 +79,7 @@ internal class RequesterRequestChannelFrameHandler(
         if (sender.isCancelled) return false
 
         val isFailed = streamsStorage.remove(id) != null
-        if (isFailed) channel.fullClose(cause)
+        if (isFailed) channel.cancelWithCause(cause)
         return isFailed
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestStreamFrameHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/handler/RequesterRequestStreamFrameHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.internal.handler
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.internal.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.channels.*
 
@@ -39,11 +40,11 @@ internal class RequesterRequestStreamFrameHandler(
 
     override fun handleError(cause: Throwable) {
         streamsStorage.remove(id)
-        channel.fullClose(cause)
+        channel.cancelWithCause(cause)
     }
 
     override fun cleanup(cause: Throwable?) {
-        channel.fullClose(cause)
+        channel.cancelWithCause(cause)
     }
 
     override fun onReceiveComplete() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.internal.io.*
 
 @ExperimentalMetadataApi
 public fun CompositeMetadata(vararg entries: Metadata): CompositeMetadata =
@@ -39,7 +40,7 @@ public sealed interface CompositeMetadata : Metadata {
     override fun BytePacketBuilder.writeSelf() {
         entries.forEach {
             writeMimeType(it.mimeType)
-            writeLength(it.content.remaining.toInt()) //write metadata length
+            writeInt24(it.content.remaining.toInt()) //write metadata length
             writePacket(it.content) //write metadata content
         }
     }
@@ -58,7 +59,7 @@ public sealed interface CompositeMetadata : Metadata {
             val list = mutableListOf<Entry>()
             while (isNotEmpty) {
                 val type = readMimeType()
-                val length = readLength()
+                val length = readInt24()
                 val packet = readPacket(pool, length)
                 list.add(Entry(type, packet))
             }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/TestConnection.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/TestConnection.kt
@@ -21,7 +21,7 @@ import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.frame.*
-import io.rsocket.kotlin.internal.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.test.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
@@ -37,13 +37,13 @@ class TestConnection : Connection, ClientTransport {
     override val coroutineContext: CoroutineContext =
         Job() + Dispatchers.Unconfined + TestExceptionHandler
 
-    private val sendChannel = Channel<ByteReadPacket>(Channel.UNLIMITED)
-    private val receiveChannel = Channel<ByteReadPacket>(Channel.UNLIMITED)
+    private val sendChannel = channelForCloseable<ByteReadPacket>(Channel.UNLIMITED)
+    private val receiveChannel = channelForCloseable<ByteReadPacket>(Channel.UNLIMITED)
 
     init {
         coroutineContext.job.invokeOnCompletion {
             sendChannel.close(it)
-            receiveChannel.fullClose(it)
+            receiveChannel.cancelWithCause(it)
         }
     }
 

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/Util.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/Util.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,18 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.test.*
 import kotlin.test.*
 
 internal fun Frame.toPacketWithLength(): ByteReadPacket = buildPacket(InUseTrackingPool) {
     val packet = toPacket(InUseTrackingPool)
-    writeLength(packet.remaining.toInt())
+    writeInt24(packet.remaining.toInt())
     writePacket(packet)
 }
 
 internal fun ByteReadPacket.toFrameWithLength(): Frame {
-    val length = readLength()
+    val length = readInt24()
     assertEquals(length, remaining.toInt())
     return readFrame(InUseTrackingPool)
 }

--- a/rsocket-internal-io/api/rsocket-internal-io.api
+++ b/rsocket-internal-io/api/rsocket-internal-io.api
@@ -1,0 +1,10 @@
+public final class io/rsocket/kotlin/internal/io/ChannelsKt {
+	public static final fun cancelWithCause (Lkotlinx/coroutines/channels/Channel;Ljava/lang/Throwable;)V
+	public static final fun channelForCloseable (I)Lkotlinx/coroutines/channels/Channel;
+}
+
+public final class io/rsocket/kotlin/internal/io/Int24Kt {
+	public static final fun readInt24 (Lio/ktor/utils/io/core/ByteReadPacket;)I
+	public static final fun writeInt24 (Lio/ktor/utils/io/core/BytePacketBuilder;I)V
+}
+

--- a/rsocket-internal-io/build.gradle.kts
+++ b/rsocket-internal-io/build.gradle.kts
@@ -15,20 +15,19 @@
  */
 
 plugins {
-    id("rsocket.template.transport")
-    id("rsocket.target.js.node")
+    id("rsocket.template.library")
+    id("rsocket.target.all")
 }
 
 kotlin {
     sourceSets {
-        jsMain {
+        commonMain {
             dependencies {
-                implementation(projects.rsocketInternalIo)
-
-                api(projects.rsocketCore)
+                api(libs.kotlinx.coroutines.core)
+                api(libs.ktor.io)
             }
         }
     }
 }
 
-description = "RSocket NodeJS TCP client/server transport implementation"
+description = "rsocket-kotlin internal IO support"

--- a/rsocket-internal-io/src/commonMain/kotlin/io/rsocket/kotlin/internal/io/Int24.kt
+++ b/rsocket-internal-io/src/commonMain/kotlin/io/rsocket/kotlin/internal/io/Int24.kt
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-plugins {
-    id("rsocket.template.transport")
-    id("rsocket.target.js.node")
+package io.rsocket.kotlin.internal.io
+
+import io.ktor.utils.io.core.*
+
+private const val lengthMask: Int = 0xFFFFFF.inv()
+
+public fun ByteReadPacket.readInt24(): Int {
+    val b = readByte().toInt() and 0xFF shl 16
+    val b1 = readByte().toInt() and 0xFF shl 8
+    val b2 = readByte().toInt() and 0xFF
+    return b or b1 or b2
 }
 
-kotlin {
-    sourceSets {
-        jsMain {
-            dependencies {
-                implementation(projects.rsocketInternalIo)
-
-                api(projects.rsocketCore)
-            }
-        }
-    }
+public fun BytePacketBuilder.writeInt24(length: Int) {
+    require(length and lengthMask == 0) { "Length is larger than 24 bits" }
+    writeByte((length shr 16).toByte())
+    writeByte((length shr 8).toByte())
+    writeByte(length.toByte())
 }
-
-description = "RSocket NodeJS TCP client/server transport implementation"

--- a/rsocket-transport-ktor/rsocket-transport-ktor-tcp/build.gradle.kts
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-tcp/build.gradle.kts
@@ -24,6 +24,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.rsocketInternalIo)
+
                 api(projects.rsocketTransportKtor)
                 api(libs.ktor.network)
             }

--- a/rsocket-transport-ktor/rsocket-transport-ktor-websocket-client/build.gradle.kts
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-websocket-client/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.rsocketCore)
                 api(projects.rsocketTransportKtor.rsocketTransportKtorWebsocket)
                 api(libs.ktor.client.core)
                 api(libs.ktor.client.websockets)

--- a/rsocket-transport-ktor/rsocket-transport-ktor-websocket-server/build.gradle.kts
+++ b/rsocket-transport-ktor/rsocket-transport-ktor-websocket-server/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.rsocketCore)
                 api(projects.rsocketTransportKtor.rsocketTransportKtorWebsocket)
                 api(libs.ktor.server.host.common)
                 api(libs.ktor.server.websockets)

--- a/rsocket-transport-local/build.gradle.kts
+++ b/rsocket-transport-local/build.gradle.kts
@@ -23,6 +23,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.rsocketInternalIo)
+
                 api(projects.rsocketCore)
             }
         }

--- a/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/FrameWithLengthAssembler.kt
+++ b/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/FrameWithLengthAssembler.kt
@@ -17,10 +17,10 @@
 package io.rsocket.kotlin.transport.nodejs.tcp
 
 import io.ktor.utils.io.core.*
-import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.internal.io.*
 
 internal fun ByteReadPacket.withLength(): ByteReadPacket = buildPacket {
-    @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") writeLength(this@withLength.remaining.toInt())
+    writeInt24(this@withLength.remaining.toInt())
     writePacket(this@withLength)
 }
 
@@ -36,7 +36,7 @@ internal class FrameWithLengthAssembler(private val onFrame: (frame: ByteReadPac
         while (true) when {
             expectedFrameLength == 0 && packetBuilder.size < 3 -> return // no length
             expectedFrameLength == 0                           -> withTemp { // has length
-                expectedFrameLength = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") it.readLength()
+                expectedFrameLength = it.readInt24()
                 if (it.remaining >= expectedFrameLength) build(it) // if has length and frame
             }
             packetBuilder.size < expectedFrameLength           -> return // not enough bytes to read frame

--- a/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpConnection.kt
+++ b/rsocket-transport-nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpConnection.kt
@@ -21,7 +21,7 @@ import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.js.*
 import io.ktor.utils.io.pool.*
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.internal.*
+import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.transport.nodejs.tcp.internal.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
@@ -32,11 +32,11 @@ import kotlin.coroutines.*
 internal class TcpConnection(
     override val coroutineContext: CoroutineContext,
     override val pool: ObjectPool<ChunkBuffer>,
-    private val socket: Socket
+    private val socket: Socket,
 ) : Connection {
 
-    private val sendChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(8)
-    private val receiveChannel = @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER") SafeChannel<ByteReadPacket>(Channel.UNLIMITED)
+    private val sendChannel = channelForCloseable<ByteReadPacket>(8)
+    private val receiveChannel = channelForCloseable<ByteReadPacket>(Channel.UNLIMITED)
 
     init {
         launch {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,6 +50,8 @@ rootProject.name = "rsocket-kotlin"
 
 //include("benchmarks")
 
+include("rsocket-internal-io")
+
 include("rsocket-core")
 include("rsocket-test")
 


### PR DESCRIPTION
### Motivation:

New module is a support module for core and transport implementations.
This allows to drop using internal declarations, as well as not exposing it to library consumers, until explicitly requested

Depends on: #244 