### PR TITLE
Deprecate old transport API for removal in next release

### DIFF
--- a/build-logic/src/main/kotlin/rsocketbuild.multiplatform-base.gradle.kts
+++ b/build-logic/src/main/kotlin/rsocketbuild.multiplatform-base.gradle.kts
@@ -51,7 +51,6 @@ kotlin {
                 optIn(OptIns.DelicateCoroutinesApi)
 
                 // rsocket related
-                optIn(OptIns.TransportApi)
                 optIn(OptIns.RSocketTransportApi)
                 optIn(OptIns.ExperimentalMetadataApi)
                 optIn(OptIns.ExperimentalStreamsApi)

--- a/build-logic/src/main/kotlin/rsocketbuild/OptIns.kt
+++ b/build-logic/src/main/kotlin/rsocketbuild/OptIns.kt
@@ -23,7 +23,6 @@ object OptIns {
     const val ExperimentalCoroutinesApi = "kotlinx.coroutines.ExperimentalCoroutinesApi"
     const val DelicateCoroutinesApi = "kotlinx.coroutines.DelicateCoroutinesApi"
 
-    const val TransportApi = "io.rsocket.kotlin.TransportApi"
     const val RSocketTransportApi = "io.rsocket.kotlin.transport.RSocketTransportApi"
     const val ExperimentalMetadataApi = "io.rsocket.kotlin.ExperimentalMetadataApi"
     const val ExperimentalStreamsApi = "io.rsocket.kotlin.ExperimentalStreamsApi"

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Annotations.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Annotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package io.rsocket.kotlin
     level = RequiresOptIn.Level.WARNING,
     message = "This is an API which is used to implement transport for RSocket, such as WS or TCP. This API can change in future in non backwards-compatible manner."
 )
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
 public annotation class TransportApi
 
 @Retention(value = AnnotationRetention.BINARY)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
@@ -19,10 +19,7 @@ package io.rsocket.kotlin
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 
-/**
- * That interface isn't stable for inheritance.
- */
-@TransportApi
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
 public interface Connection : CoroutineScope {
     public suspend fun send(packet: ByteReadPacket)
     public suspend fun receive(): ByteReadPacket

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/connection/OldConnection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/connection/OldConnection.kt
@@ -24,7 +24,7 @@ import io.rsocket.kotlin.transport.internal.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
 @RSocketTransportApi
 internal suspend fun RSocketConnectionHandler.handleConnection(connection: Connection): Unit = coroutineScope {
     val outboundQueue = PrioritizationFrameQueue(Channel.BUFFERED)
@@ -43,7 +43,7 @@ internal suspend fun RSocketConnectionHandler.handleConnection(connection: Conne
     }
 }
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
 @RSocketTransportApi
 private class OldConnection(
     private val outboundQueue: PrioritizationFrameQueue,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/InterceptorsBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/InterceptorsBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(TransportApi::class)
 
 package io.rsocket.kotlin.core
 
 import io.rsocket.kotlin.*
 
+@Suppress("DEPRECATION_ERROR")
 public class InterceptorsBuilder internal constructor() {
     private val requesters = mutableListOf<Interceptor<RSocket>>()
     private val responders = mutableListOf<Interceptor<RSocket>>()
@@ -33,7 +33,7 @@ public class InterceptorsBuilder internal constructor() {
         responders += interceptor
     }
 
-    @TransportApi
+    @Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated without replacement")
     public fun forConnection(interceptor: Interceptor<Connection>) {
         connections += interceptor
     }
@@ -45,6 +45,7 @@ public class InterceptorsBuilder internal constructor() {
     internal fun build(): Interceptors = Interceptors(requesters, responders, connections, acceptors)
 }
 
+@Suppress("DEPRECATION_ERROR")
 internal class Interceptors(
     private val requesters: List<Interceptor<RSocket>>,
     private val responders: List<Interceptor<RSocket>>,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -27,7 +27,7 @@ import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
-@OptIn(TransportApi::class, RSocketTransportApi::class, RSocketLoggingApi::class)
+@OptIn(RSocketTransportApi::class, RSocketLoggingApi::class)
 public class RSocketConnector internal constructor(
     loggerFactory: LoggerFactory,
     private val maxFragmentSize: Int,
@@ -40,6 +40,8 @@ public class RSocketConnector internal constructor(
     private val connectionLogger = loggerFactory.logger("io.rsocket.kotlin.connection")
     private val frameLogger = loggerFactory.logger("io.rsocket.kotlin.frame")
 
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
     public suspend fun connect(transport: ClientTransport): RSocket = connect(object : RSocketClientTarget {
         override val coroutineContext: CoroutineContext get() = transport.coroutineContext
         override fun connectClient(handler: RSocketConnectionHandler): Job = launch {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -25,7 +25,7 @@ import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 
-@OptIn(TransportApi::class, RSocketTransportApi::class, RSocketLoggingApi::class)
+@OptIn(RSocketTransportApi::class, RSocketLoggingApi::class)
 public class RSocketServer internal constructor(
     loggerFactory: LoggerFactory,
     private val maxFragmentSize: Int,
@@ -34,12 +34,16 @@ public class RSocketServer internal constructor(
 ) {
     private val frameLogger = loggerFactory.logger("io.rsocket.kotlin.frame")
 
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
     @DelicateCoroutinesApi
     public fun <T> bind(
         transport: ServerTransport<T>,
         acceptor: ConnectionAcceptor,
     ): T = bindIn(GlobalScope, transport, acceptor)
 
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
     public fun <T> bindIn(
         scope: CoroutineScope,
         transport: ServerTransport<T>,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ClientTransport.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ClientTransport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,17 @@ import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
 public fun interface ClientTransport : CoroutineScope {
     override val coroutineContext: CoroutineContext get() = EmptyCoroutineContext
-
-    @TransportApi
     public suspend fun connect(): Connection
 }
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
 public fun ClientTransport(coroutineContext: CoroutineContext, transport: ClientTransport): ClientTransport =
     object : ClientTransport {
         override val coroutineContext: CoroutineContext get() = coroutineContext
-
-        @TransportApi
         override suspend fun connect(): Connection = transport.connect()
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ServerTransport.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/transport/ServerTransport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package io.rsocket.kotlin.transport
 import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
 public fun interface ServerTransport<T> {
-    @TransportApi
     public fun CoroutineScope.start(accept: suspend CoroutineScope.(Connection) -> Unit): T
 }

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/RSocketTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/core/RSocketTest.kt
@@ -30,6 +30,7 @@ import kotlin.coroutines.*
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("DEPRECATION_ERROR")
 class OldLocalRSocketTest : RSocketTest({ context, acceptor ->
     val localServer = TestServer().bindIn(
         CoroutineScope(context),

--- a/rsocket-transport-tests/src/commonMain/kotlin/io/rsocket/kotlin/transport/tests/TransportTest.kt
+++ b/rsocket-transport-tests/src/commonMain/kotlin/io/rsocket/kotlin/transport/tests/TransportTest.kt
@@ -40,9 +40,11 @@ abstract class TransportTest : SuspendTest, TestWithLeakCheck {
 
     protected lateinit var client: RSocket
 
+    @Suppress("DEPRECATION_ERROR")
     protected suspend fun connectClient(clientTransport: ClientTransport): RSocket =
         CONNECTOR.connect(clientTransport)
 
+    @Suppress("DEPRECATION_ERROR")
     protected fun <T> startServer(serverTransport: ServerTransport<T>): T =
         SERVER.bindIn(testScope, serverTransport, ACCEPTOR)
 

--- a/rsocket-transports/ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpClientTransport.kt
+++ b/rsocket-transports/ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpClientTransport.kt
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-@file:OptIn(TransportApi::class)
 @file:Suppress("FunctionName")
 
 package io.rsocket.kotlin.transport.ktor.tcp
 
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
-import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorTcpClientTransport")
 public fun TcpClientTransport(
     hostname: String, port: Int,
     context: CoroutineContext = EmptyCoroutineContext,
@@ -33,6 +33,8 @@ public fun TcpClientTransport(
     configure: SocketOptions.TCPClientSocketOptions.() -> Unit = {},
 ): ClientTransport = TcpClientTransport(InetSocketAddress(hostname, port), context, intercept, configure)
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorTcpClientTransport")
 public fun TcpClientTransport(
     remoteAddress: InetSocketAddress,
     context: CoroutineContext = EmptyCoroutineContext,

--- a/rsocket-transports/ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpConnection.kt
+++ b/rsocket-transports/ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpConnection.kt
@@ -20,17 +20,15 @@ import io.ktor.network.sockets.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
-import io.rsocket.kotlin.*
-import io.rsocket.kotlin.Connection
 import io.rsocket.kotlin.internal.io.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
 internal class TcpConnection(
     socket: Socket,
     override val coroutineContext: CoroutineContext,
-) : Connection {
+) : io.rsocket.kotlin.Connection {
     private val socketConnection = socket.connection()
 
     private val sendChannel = channelForCloseable<ByteReadPacket>(8)

--- a/rsocket-transports/ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpServerTransport.kt
+++ b/rsocket-transports/ktor-tcp/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpServerTransport.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(TransportApi::class)
 @file:Suppress("FunctionName")
 
 package io.rsocket.kotlin.transport.ktor.tcp
@@ -22,20 +21,24 @@ package io.rsocket.kotlin.transport.ktor.tcp
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.utils.io.core.*
-import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*
 
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorTcpServerInstance")
 public class TcpServer internal constructor(
     public val handlerJob: Job,
     public val serverSocket: Deferred<ServerSocket>
 )
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorTcpServerTransport")
 public fun TcpServerTransport(
     hostname: String = "0.0.0.0", port: Int = 0,
     configure: SocketOptions.AcceptorOptions.() -> Unit = {},
 ): ServerTransport<TcpServer> = TcpServerTransport(InetSocketAddress(hostname, port), configure)
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorTcpServerTransport")
 public fun TcpServerTransport(
     localAddress: InetSocketAddress? = null,
     configure: SocketOptions.AcceptorOptions.() -> Unit = {},

--- a/rsocket-transports/ktor-tcp/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpTransportTest.kt
+++ b/rsocket-transports/ktor-tcp/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/tcp/TcpTransportTest.kt
@@ -21,6 +21,7 @@ import io.ktor.network.sockets.*
 import io.rsocket.kotlin.transport.tests.*
 import kotlinx.coroutines.*
 
+@Suppress("DEPRECATION_ERROR")
 class TcpTransportTest : TransportTest() {
     override suspend fun before() {
         val serverSocket = startServer(TcpServerTransport()).serverSocket.await()

--- a/rsocket-transports/ktor-websocket-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/websocket/client/WebSocketClientTransport.kt
+++ b/rsocket-transports/ktor-websocket-client/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/websocket/client/WebSocketClientTransport.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(TransportApi::class)
 @file:Suppress("FunctionName")
 
 package io.rsocket.kotlin.transport.ktor.websocket.client
@@ -24,14 +23,13 @@ import io.ktor.client.engine.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 import io.rsocket.kotlin.transport.ktor.websocket.internal.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
-//TODO: will be reworked later with transport API rework
-
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorWebSocketClientTransport")
 public fun <T : HttpClientEngineConfig> WebSocketClientTransport(
     engineFactory: HttpClientEngineFactory<T>,
     context: CoroutineContext = EmptyCoroutineContext,
@@ -61,6 +59,8 @@ public fun <T : HttpClientEngineConfig> WebSocketClientTransport(
     }
 }
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorWebSocketClientTransport")
 public fun <T : HttpClientEngineConfig> WebSocketClientTransport(
     engineFactory: HttpClientEngineFactory<T>,
     urlString: String, secure: Boolean = false,
@@ -77,6 +77,8 @@ public fun <T : HttpClientEngineConfig> WebSocketClientTransport(
     request()
 }
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorWebSocketClientTransport")
 public fun <T : HttpClientEngineConfig> WebSocketClientTransport(
     engineFactory: HttpClientEngineFactory<T>,
     host: String? = null,

--- a/rsocket-transports/ktor-websocket-internal/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/websocket/internal/WebSocketConnection.kt
+++ b/rsocket-transports/ktor-websocket-internal/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/websocket/internal/WebSocketConnection.kt
@@ -21,7 +21,8 @@ import io.ktor.websocket.*
 import io.rsocket.kotlin.*
 import kotlinx.coroutines.*
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API")
 public class WebSocketConnection(
     private val session: WebSocketSession,
 ) : Connection, CoroutineScope by session {

--- a/rsocket-transports/ktor-websocket-server/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/websocket/server/WebSocketServerTransport.kt
+++ b/rsocket-transports/ktor-websocket-server/src/commonMain/kotlin/io/rsocket/kotlin/transport/ktor/websocket/server/WebSocketServerTransport.kt
@@ -20,11 +20,11 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
-import io.rsocket.kotlin.*
 import io.rsocket.kotlin.transport.*
 import io.rsocket.kotlin.transport.ktor.websocket.internal.*
 
-@Suppress("FunctionName")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorWebSocketServerTransport")
+@Suppress("DEPRECATION_ERROR", "FunctionName")
 public fun <A : ApplicationEngine, T : ApplicationEngine.Configuration> WebSocketServerTransport(
     engineFactory: ApplicationEngineFactory<A, T>,
     port: Int = 80, host: String = "0.0.0.0",
@@ -43,8 +43,8 @@ public fun <A : ApplicationEngine, T : ApplicationEngine.Configuration> WebSocke
     webSockets = webSockets,
 )
 
-@Suppress("FunctionName")
-@OptIn(TransportApi::class)
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use KtorWebSocketServerTransport")
+@Suppress("DEPRECATION_ERROR", "FunctionName")
 public fun <A : ApplicationEngine, T : ApplicationEngine.Configuration> WebSocketServerTransport(
     engineFactory: ApplicationEngineFactory<A, T>,
     vararg connectors: EngineConnectorConfig,

--- a/rsocket-transports/ktor-websocket-server/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/websocket/server/WebSocketTransportTest.kt
+++ b/rsocket-transports/ktor-websocket-server/src/commonTest/kotlin/io/rsocket/kotlin/transport/ktor/websocket/server/WebSocketTransportTest.kt
@@ -21,6 +21,7 @@ import io.ktor.server.engine.*
 import io.rsocket.kotlin.transport.ktor.websocket.client.*
 import io.rsocket.kotlin.transport.tests.*
 
+@Suppress("DEPRECATION_ERROR")
 abstract class WebSocketTransportTest(
     private val clientEngine: HttpClientEngineFactory<*>,
     private val serverEngine: ApplicationEngineFactory<*, *>,

--- a/rsocket-transports/local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalConnection.kt
+++ b/rsocket-transports/local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalConnection.kt
@@ -21,7 +21,7 @@ import io.rsocket.kotlin.*
 import kotlinx.coroutines.channels.*
 import kotlin.coroutines.*
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
 internal class LocalConnection(
     private val sender: SendChannel<ByteReadPacket>,
     private val receiver: ReceiveChannel<ByteReadPacket>,

--- a/rsocket-transports/local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
+++ b/rsocket-transports/local/src/commonMain/kotlin/io/rsocket/kotlin/transport/local/LocalServer.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(TransportApi::class)
 @file:Suppress("FunctionName")
 
 package io.rsocket.kotlin.transport.local
@@ -28,6 +27,8 @@ import kotlinx.coroutines.channels.*
 import kotlin.coroutines.*
 import kotlin.js.*
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use LocalServerTransport with parameters")
 @JsName("LocalServerTransport2") // for compatibility with new API
 public fun LocalServerTransport(): ServerTransport<LocalServer> = ServerTransport { accept ->
     val connections = Channel<Connection>()
@@ -41,6 +42,8 @@ public fun LocalServerTransport(): ServerTransport<LocalServer> = ServerTranspor
     LocalServer(connections, coroutineContext + SupervisorJob(handlerJob))
 }
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use LocalServerInstance")
 public class LocalServer internal constructor(
     private val connections: Channel<Connection>,
     override val coroutineContext: CoroutineContext,

--- a/rsocket-transports/local/src/commonTest/kotlin/io/rsocket/kotlin/transport/local/LocalTransportTest.kt
+++ b/rsocket-transports/local/src/commonTest/kotlin/io/rsocket/kotlin/transport/local/LocalTransportTest.kt
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.transport.local
 import io.rsocket.kotlin.transport.tests.*
 import kotlinx.coroutines.channels.*
 
+@Suppress("DEPRECATION_ERROR")
 class OldLocalTransportTest : TransportTest() {
     override suspend fun before() {
         val server = startServer(LocalServerTransport())

--- a/rsocket-transports/nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpClientTransport.kt
+++ b/rsocket-transports/nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpClientTransport.kt
@@ -22,15 +22,16 @@ import io.rsocket.kotlin.transport.nodejs.tcp.internal.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use NodejsTcpClientTransport")
 public class TcpClientTransport(
     private val port: Int,
     private val hostname: String,
-    coroutineContext: CoroutineContext = EmptyCoroutineContext
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : ClientTransport {
 
     override val coroutineContext: CoroutineContext = coroutineContext + SupervisorJob(coroutineContext[Job])
 
-    @TransportApi
     override suspend fun connect(): Connection {
         val socket = connect(port, hostname)
         return TcpConnection(coroutineContext, socket)

--- a/rsocket-transports/nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpConnection.kt
+++ b/rsocket-transports/nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpConnection.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.*
 import org.khronos.webgl.*
 import kotlin.coroutines.*
 
-@TransportApi
+@Suppress("DEPRECATION_ERROR")
 internal class TcpConnection(
     override val coroutineContext: CoroutineContext,
     private val socket: Socket,

--- a/rsocket-transports/nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpServerTransport.kt
+++ b/rsocket-transports/nodejs-tcp/src/jsMain/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpServerTransport.kt
@@ -22,6 +22,7 @@ import io.rsocket.kotlin.transport.nodejs.tcp.internal.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use NodejsTcpServerInstance")
 public class TcpServer internal constructor(
     public val job: Job, private val server: Server
 ) {
@@ -30,10 +31,11 @@ public class TcpServer internal constructor(
     }
 }
 
+@Suppress("DEPRECATION_ERROR")
+@Deprecated(level = DeprecationLevel.ERROR, message = "Deprecated in favor of new Transport API, use NodejsTcpServerTransport")
 public class TcpServerTransport(
     private val port: Int, private val hostname: String,
 ) : ServerTransport<TcpServer> {
-    @TransportApi
     override fun CoroutineScope.start(accept: suspend CoroutineScope.(Connection) -> Unit): TcpServer {
         val supervisorJob = SupervisorJob(coroutineContext[Job])
         val server = createServer(port, hostname, { supervisorJob.cancel() }) {

--- a/rsocket-transports/nodejs-tcp/src/jsTest/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpTransportTest.kt
+++ b/rsocket-transports/nodejs-tcp/src/jsTest/kotlin/io/rsocket/kotlin/transport/nodejs/tcp/TcpTransportTest.kt
@@ -19,6 +19,7 @@ package io.rsocket.kotlin.transport.nodejs.tcp
 import io.rsocket.kotlin.transport.tests.*
 import kotlinx.coroutines.*
 
+@Suppress("DEPRECATION_ERROR")
 class TcpTransportTest : TransportTest() {
     private lateinit var server: TcpServer
 


### PR DESCRIPTION
* Old transport implementations are deprecated for removal in next release