### PR TITLE
Fix custom MIME type serialization incompatibility (#260)

### DIFF
--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/io/MimeTypeTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/io/MimeTypeTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.frame.io
+
+import io.rsocket.kotlin.core.*
+import io.rsocket.kotlin.test.*
+import kotlin.test.*
+
+class MimeTypeTest : TestWithLeakCheck {
+
+    @Test
+    fun customMimeTypeSerialization() {
+        testCustomMimeType("message/x.foo")
+        testCustomMimeType(randomAsciiString(1))
+        testCustomMimeType(randomAsciiString(127))
+        testCustomMimeType(randomAsciiString(128))
+    }
+
+    private fun testCustomMimeType(name: String) {
+        val mimeType = CustomMimeType(name)
+        val packet = packet {
+            writeMimeType(mimeType)
+        }
+        assertEquals(name.length - 1, packet.tryPeek())
+        assertEquals(mimeType, packet.readMimeType())
+    }
+}

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/io/Util.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/frame/io/Util.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.kotlin.frame.io
+
+
+private val asciiChars = '!'..'~'
+
+internal fun randomAsciiString(length: Int): String {
+    return (1..length).joinToString(separator = "") { asciiChars.random().toString() }
+}


### PR DESCRIPTION
Adjust MIME type name length serialization to ensure compatibility with other RSocket implementations.