### PR TITLE
Move `BufferPool` to `internal` package of `core` module because of its exposure in metadata API

### DIFF
--- a/rsocket-core/api/rsocket-core.api
+++ b/rsocket-core/api/rsocket-core.api
@@ -199,14 +199,14 @@ public final class io/rsocket/kotlin/core/RSocketConnector {
 public final class io/rsocket/kotlin/core/RSocketConnectorBuilder {
 	public final fun acceptor (Lio/rsocket/kotlin/ConnectionAcceptor;)V
 	public final fun connectionConfig (Lkotlin/jvm/functions/Function1;)V
-	public final fun getBufferPool-ulmh1bs ()Lio/ktor/utils/io/pool/ObjectPool;
+	public final fun getBufferPool-7b3xaDw ()Lio/ktor/utils/io/pool/ObjectPool;
 	public final fun getLoggerFactory ()Lio/rsocket/kotlin/logging/LoggerFactory;
 	public final fun getMaxFragmentSize ()I
 	public final fun interceptors (Lkotlin/jvm/functions/Function1;)V
 	public final fun reconnectable (JLkotlin/jvm/functions/Function2;)V
 	public final fun reconnectable (Lkotlin/jvm/functions/Function3;)V
 	public static synthetic fun reconnectable$default (Lio/rsocket/kotlin/core/RSocketConnectorBuilder;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public final fun setBufferPool-nnChvZA (Lio/ktor/utils/io/pool/ObjectPool;)V
+	public final fun setBufferPool-vHF7wRk (Lio/ktor/utils/io/pool/ObjectPool;)V
 	public final fun setLoggerFactory (Lio/rsocket/kotlin/logging/LoggerFactory;)V
 	public final fun setMaxFragmentSize (I)V
 }
@@ -231,11 +231,11 @@ public final class io/rsocket/kotlin/core/RSocketServer {
 }
 
 public final class io/rsocket/kotlin/core/RSocketServerBuilder {
-	public final fun getBufferPool-ulmh1bs ()Lio/ktor/utils/io/pool/ObjectPool;
+	public final fun getBufferPool-7b3xaDw ()Lio/ktor/utils/io/pool/ObjectPool;
 	public final fun getLoggerFactory ()Lio/rsocket/kotlin/logging/LoggerFactory;
 	public final fun getMaxFragmentSize ()I
 	public final fun interceptors (Lkotlin/jvm/functions/Function1;)V
-	public final fun setBufferPool-nnChvZA (Lio/ktor/utils/io/pool/ObjectPool;)V
+	public final fun setBufferPool-vHF7wRk (Lio/ktor/utils/io/pool/ObjectPool;)V
 	public final fun setLoggerFactory (Lio/rsocket/kotlin/logging/LoggerFactory;)V
 	public final fun setMaxFragmentSize (I)V
 }
@@ -318,6 +318,25 @@ public final class io/rsocket/kotlin/core/WellKnownMimeType : java/lang/Enum, io
 public final class io/rsocket/kotlin/core/WellKnownMimeType$Companion {
 	public final fun invoke (B)Lio/rsocket/kotlin/core/WellKnownMimeType;
 	public final fun invoke (Ljava/lang/String;)Lio/rsocket/kotlin/core/WellKnownMimeType;
+}
+
+public final class io/rsocket/kotlin/internal/BufferPool {
+	public static final field Companion Lio/rsocket/kotlin/internal/BufferPool$Companion;
+	public static final synthetic fun box-impl (Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/internal/BufferPool;
+	public static final fun buildPacket-impl (Lio/ktor/utils/io/pool/ObjectPool;Lkotlin/jvm/functions/Function1;)Lio/ktor/utils/io/core/ByteReadPacket;
+	public static fun constructor-impl (Lio/ktor/utils/io/pool/ObjectPool;)Lio/ktor/utils/io/pool/ObjectPool;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lio/ktor/utils/io/pool/ObjectPool;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lio/ktor/utils/io/pool/ObjectPool;Lio/ktor/utils/io/pool/ObjectPool;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lio/ktor/utils/io/pool/ObjectPool;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lio/ktor/utils/io/pool/ObjectPool;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lio/ktor/utils/io/pool/ObjectPool;
+}
+
+public final class io/rsocket/kotlin/internal/BufferPool$Companion {
+	public final fun getDefault-7b3xaDw ()Lio/ktor/utils/io/pool/ObjectPool;
 }
 
 public final class io/rsocket/kotlin/keepalive/KeepAlive {
@@ -420,8 +439,8 @@ public final class io/rsocket/kotlin/metadata/CompositeMetadata$Entry {
 
 public final class io/rsocket/kotlin/metadata/CompositeMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/CompositeMetadata;
-	public synthetic fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/CompositeMetadata;
+	public synthetic fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
 }
 
 public abstract interface class io/rsocket/kotlin/metadata/CompositeMetadataBuilder : java/io/Closeable {
@@ -444,10 +463,10 @@ public final class io/rsocket/kotlin/metadata/CompositeMetadataExtensionsKt {
 	public static final fun hasMimeTypeOf (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;)Z
 	public static final fun list (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Ljava/util/List;
 	public static final fun list (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/metadata/MetadataReader;)Ljava/util/List;
-	public static final fun read-FTxoUho (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public static synthetic fun read-FTxoUho$default (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/Metadata;
-	public static final fun readOrNull-FTxoUho (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public static synthetic fun readOrNull-FTxoUho$default (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static final fun read-jfyA9PI (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static synthetic fun read-jfyA9PI$default (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static final fun readOrNull-jfyA9PI (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static synthetic fun readOrNull-jfyA9PI$default (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/Metadata;
 }
 
 public final class io/rsocket/kotlin/metadata/CompositeMetadataFromBuilder : io/rsocket/kotlin/metadata/CompositeMetadata, io/rsocket/kotlin/metadata/CompositeMetadataBuilder {
@@ -469,15 +488,15 @@ public abstract interface class io/rsocket/kotlin/metadata/Metadata : java/io/Cl
 
 public final class io/rsocket/kotlin/metadata/MetadataKt {
 	public static final fun metadata (Lio/rsocket/kotlin/payload/PayloadBuilder;Lio/rsocket/kotlin/metadata/Metadata;)V
-	public static final fun read-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public static synthetic fun read-FTxoUho$default (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/Metadata;
-	public static final fun toPacket-sXCisgc (Lio/rsocket/kotlin/metadata/Metadata;Lio/ktor/utils/io/pool/ObjectPool;)Lio/ktor/utils/io/core/ByteReadPacket;
-	public static synthetic fun toPacket-sXCisgc$default (Lio/rsocket/kotlin/metadata/Metadata;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/ktor/utils/io/core/ByteReadPacket;
+	public static final fun read-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static synthetic fun read-jfyA9PI$default (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/MetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static final fun toPacket-B471DwU (Lio/rsocket/kotlin/metadata/Metadata;Lio/ktor/utils/io/pool/ObjectPool;)Lio/ktor/utils/io/core/ByteReadPacket;
+	public static synthetic fun toPacket-B471DwU$default (Lio/rsocket/kotlin/metadata/Metadata;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/ktor/utils/io/core/ByteReadPacket;
 }
 
 public abstract interface class io/rsocket/kotlin/metadata/MetadataReader {
 	public abstract fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public abstract fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public abstract fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
 }
 
 public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata : io/rsocket/kotlin/metadata/Metadata {
@@ -491,8 +510,8 @@ public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMe
 
 public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata;
+	public synthetic fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadataKt {
@@ -510,8 +529,8 @@ public final class io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata : io
 
 public final class io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata;
+	public synthetic fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/RawMetadata : io/rsocket/kotlin/metadata/Metadata {
@@ -538,8 +557,8 @@ public final class io/rsocket/kotlin/metadata/RoutingMetadata : io/rsocket/kotli
 
 public final class io/rsocket/kotlin/metadata/RoutingMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/RoutingMetadata;
+	public synthetic fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/RoutingMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/RoutingMetadataKt {
@@ -573,8 +592,8 @@ public final class io/rsocket/kotlin/metadata/ZipkinTracingMetadata$Kind : java/
 
 public final class io/rsocket/kotlin/metadata/ZipkinTracingMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/ZipkinTracingMetadata;
+	public synthetic fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/ZipkinTracingMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/ZipkinTracingMetadataKt {
@@ -594,9 +613,9 @@ public abstract interface class io/rsocket/kotlin/metadata/security/AuthMetadata
 
 public abstract interface class io/rsocket/kotlin/metadata/security/AuthMetadataReader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read-sXCisgc (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public abstract fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public synthetic fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read-B471DwU (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public abstract fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
 }
 
 public abstract interface class io/rsocket/kotlin/metadata/security/AuthType {
@@ -620,8 +639,8 @@ public final class io/rsocket/kotlin/metadata/security/BearerAuthMetadata : io/r
 }
 
 public final class io/rsocket/kotlin/metadata/security/BearerAuthMetadata$Reader : io/rsocket/kotlin/metadata/security/AuthMetadataReader {
-	public synthetic fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/BearerAuthMetadata;
+	public synthetic fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/BearerAuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/CustomAuthType : io/rsocket/kotlin/metadata/security/AuthTypeWithName {
@@ -645,16 +664,16 @@ public final class io/rsocket/kotlin/metadata/security/RawAuthMetadata : io/rsoc
 }
 
 public final class io/rsocket/kotlin/metadata/security/RawAuthMetadata$Reader : io/rsocket/kotlin/metadata/security/AuthMetadataReader {
-	public synthetic fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;
+	public synthetic fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/RawAuthMetadataKt {
 	public static final fun hasAuthTypeOf (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;)Z
-	public static final fun read-FTxoUho (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public static synthetic fun read-FTxoUho$default (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public static final fun readOrNull-FTxoUho (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public static synthetic fun readOrNull-FTxoUho$default (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public static final fun read-jfyA9PI (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public static synthetic fun read-jfyA9PI$default (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public static final fun readOrNull-jfyA9PI (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public static synthetic fun readOrNull-jfyA9PI$default (Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;Lio/rsocket/kotlin/metadata/security/AuthMetadataReader;Lio/ktor/utils/io/pool/ObjectPool;ILjava/lang/Object;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/ReservedAuthType : io/rsocket/kotlin/metadata/security/AuthTypeWithId {
@@ -679,8 +698,8 @@ public final class io/rsocket/kotlin/metadata/security/SimpleAuthMetadata : io/r
 }
 
 public final class io/rsocket/kotlin/metadata/security/SimpleAuthMetadata$Reader : io/rsocket/kotlin/metadata/security/AuthMetadataReader {
-	public synthetic fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public fun readContent-FTxoUho (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/SimpleAuthMetadata;
+	public synthetic fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public fun readContent-jfyA9PI (Lio/ktor/utils/io/core/ByteReadPacket;Lio/rsocket/kotlin/metadata/security/AuthType;Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/metadata/security/SimpleAuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/WellKnowAuthType : java/lang/Enum, io/rsocket/kotlin/metadata/security/AuthTypeWithId, io/rsocket/kotlin/metadata/security/AuthTypeWithName {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/Connection.kt
@@ -19,7 +19,6 @@ package io.rsocket.kotlin
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.internal.*
-import io.rsocket.kotlin.internal.io.*
 import kotlinx.coroutines.*
 
 /**

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnector.kt
@@ -20,7 +20,6 @@ import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.internal.*
-import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketConnectorBuilder.kt
@@ -18,7 +18,6 @@ package io.rsocket.kotlin.core
 
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.internal.*
-import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.payload.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServer.kt
@@ -20,7 +20,6 @@ import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.frame.io.*
 import io.rsocket.kotlin.internal.*
-import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.logging.*
 import io.rsocket.kotlin.transport.*
 import kotlinx.coroutines.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServerBuilder.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/core/RSocketServerBuilder.kt
@@ -17,7 +17,7 @@
 package io.rsocket.kotlin.core
 
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.logging.*
 
 public class RSocketServerBuilder internal constructor() {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 
 internal class ExtensionFrame(

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/Frame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 private const val FlagsMask: Int = 1023
 private const val FrameTypeShift: Int = 10

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 private const val RespondFlag = 128
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 internal class LeaseFrame(
     val ttl: Int,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 internal class MetadataPushFrame(
     val metadata: ByteReadPacket,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
@@ -20,7 +20,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 
 internal class RequestFrame(

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 internal class ResumeFrame(
     val version: Version,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.keepalive.*
 import io.rsocket.kotlin.payload.*
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
@@ -17,6 +17,7 @@
 package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
@@ -17,7 +17,7 @@
 package io.rsocket.kotlin.frame.io
 
 import io.ktor.utils.io.core.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 internal fun ByteReadPacket.readResumeToken(pool: BufferPool): ByteReadPacket {
     val length = readShort().toInt() and 0xFFFF

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/BufferPool.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/BufferPool.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket.kotlin.internal.io
+package io.rsocket.kotlin.internal
 
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/Connect.kt
@@ -19,7 +19,6 @@ package io.rsocket.kotlin.internal
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.*
-import io.rsocket.kotlin.internal.io.*
 import kotlinx.coroutines.*
 
 @OptIn(TransportApi::class)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/FrameSender.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/FrameSender.kt
@@ -19,7 +19,6 @@ package io.rsocket.kotlin.internal
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.frame.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.coroutines.*
 import kotlin.math.*

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/internal/LoggingConnection.kt
@@ -21,7 +21,6 @@ package io.rsocket.kotlin.internal
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.*
-import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.logging.*
 
 internal fun Connection.logging(logger: Logger, bufferPool: BufferPool): Connection =

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
@@ -20,6 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.internal.io.*
 
 @ExperimentalMetadataApi

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
@@ -19,7 +19,7 @@ package io.rsocket.kotlin.metadata
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public fun CompositeMetadata.Entry.hasMimeTypeOf(reader: MetadataReader<*>): Boolean = mimeType == reader.mimeType

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
@@ -19,7 +19,7 @@ package io.rsocket.kotlin.metadata
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.payload.*
 
 @ExperimentalMetadataApi

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public fun PerStreamAcceptableDataMimeTypesMetadata(vararg tags: MimeType): PerStreamAcceptableDataMimeTypesMetadata =

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public class PerStreamDataMimeTypeMetadata(public val type: MimeType) : Metadata {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public class RawMetadata(

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
@@ -19,7 +19,7 @@ package io.rsocket.kotlin.metadata
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public fun RoutingMetadata(vararg tags: String): RoutingMetadata = RoutingMetadata(tags.toList())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import kotlin.experimental.*
 
 @ExperimentalMetadataApi

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.core.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import io.rsocket.kotlin.metadata.*
 
 @ExperimentalMetadataApi

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.metadata.security
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public class BearerAuthMetadata(

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
@@ -19,7 +19,7 @@ package io.rsocket.kotlin.metadata.security
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
 import io.rsocket.kotlin.frame.io.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public class RawAuthMetadata(

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.metadata.security
 
 import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 
 @ExperimentalMetadataApi
 public class SimpleAuthMetadata(

--- a/rsocket-internal-io/api/rsocket-internal-io.api
+++ b/rsocket-internal-io/api/rsocket-internal-io.api
@@ -1,22 +1,3 @@
-public final class io/rsocket/kotlin/internal/io/BufferPool {
-	public static final field Companion Lio/rsocket/kotlin/internal/io/BufferPool$Companion;
-	public static final synthetic fun box-impl (Lio/ktor/utils/io/pool/ObjectPool;)Lio/rsocket/kotlin/internal/io/BufferPool;
-	public static final fun buildPacket-impl (Lio/ktor/utils/io/pool/ObjectPool;Lkotlin/jvm/functions/Function1;)Lio/ktor/utils/io/core/ByteReadPacket;
-	public static fun constructor-impl (Lio/ktor/utils/io/pool/ObjectPool;)Lio/ktor/utils/io/pool/ObjectPool;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lio/ktor/utils/io/pool/ObjectPool;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lio/ktor/utils/io/pool/ObjectPool;Lio/ktor/utils/io/pool/ObjectPool;)Z
-	public fun hashCode ()I
-	public static fun hashCode-impl (Lio/ktor/utils/io/pool/ObjectPool;)I
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lio/ktor/utils/io/pool/ObjectPool;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lio/ktor/utils/io/pool/ObjectPool;
-}
-
-public final class io/rsocket/kotlin/internal/io/BufferPool$Companion {
-	public final fun getDefault-ulmh1bs ()Lio/ktor/utils/io/pool/ObjectPool;
-}
-
 public final class io/rsocket/kotlin/internal/io/ChannelsKt {
 	public static final fun cancelWithCause (Lkotlinx/coroutines/channels/Channel;Ljava/lang/Throwable;)V
 	public static final fun channelForCloseable (I)Lkotlinx/coroutines/channels/Channel;

--- a/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/InUseTrackingPool.kt
+++ b/rsocket-test/src/commonMain/kotlin/io/rsocket/kotlin/test/InUseTrackingPool.kt
@@ -20,7 +20,7 @@ import io.ktor.utils.io.bits.*
 import io.ktor.utils.io.core.*
 import io.ktor.utils.io.core.internal.*
 import io.ktor.utils.io.pool.*
-import io.rsocket.kotlin.internal.io.*
+import io.rsocket.kotlin.internal.*
 import kotlinx.atomicfu.locks.*
 import kotlin.test.*
 


### PR DESCRIPTION
`rsocket-internal-io` classes/functions should be not exposed to users, as it's declared as `implementation` dependency and should not be used directly