### PR TITLE
Remove usage of `Source` where missed, as for now the main primitive should be `Buffer`

### DIFF
--- a/rsocket-core/api/rsocket-core.api
+++ b/rsocket-core/api/rsocket-core.api
@@ -416,8 +416,8 @@ public final class io/rsocket/kotlin/metadata/CompositeMetadata$Entry {
 
 public final class io/rsocket/kotlin/metadata/CompositeMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/CompositeMetadata;
-	public synthetic fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/CompositeMetadata;
+	public synthetic fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
 }
 
 public abstract interface class io/rsocket/kotlin/metadata/CompositeMetadataBuilder : java/lang/AutoCloseable {
@@ -433,9 +433,9 @@ public final class io/rsocket/kotlin/metadata/CompositeMetadataBuilderKt {
 public final class io/rsocket/kotlin/metadata/CompositeMetadataExtensionsKt {
 	public static final fun contains (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Z
 	public static final fun contains (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/metadata/MetadataReader;)Z
-	public static final fun get (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Lkotlinx/io/Source;
+	public static final fun get (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Lkotlinx/io/Buffer;
 	public static final fun get (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/metadata/MetadataReader;)Lio/rsocket/kotlin/metadata/Metadata;
-	public static final fun getOrNull (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Lkotlinx/io/Source;
+	public static final fun getOrNull (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Lkotlinx/io/Buffer;
 	public static final fun getOrNull (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/metadata/MetadataReader;)Lio/rsocket/kotlin/metadata/Metadata;
 	public static final fun hasMimeTypeOf (Lio/rsocket/kotlin/metadata/CompositeMetadata$Entry;Lio/rsocket/kotlin/metadata/MetadataReader;)Z
 	public static final fun list (Lio/rsocket/kotlin/metadata/CompositeMetadata;Lio/rsocket/kotlin/core/MimeType;)Ljava/util/List;
@@ -463,13 +463,13 @@ public abstract interface class io/rsocket/kotlin/metadata/Metadata : java/lang/
 
 public final class io/rsocket/kotlin/metadata/MetadataKt {
 	public static final fun metadata (Lio/rsocket/kotlin/payload/PayloadBuilder;Lio/rsocket/kotlin/metadata/Metadata;)V
-	public static final fun read (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/MetadataReader;)Lio/rsocket/kotlin/metadata/Metadata;
+	public static final fun read (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/MetadataReader;)Lio/rsocket/kotlin/metadata/Metadata;
 	public static final fun toBuffer (Lio/rsocket/kotlin/metadata/Metadata;)Lkotlinx/io/Buffer;
 }
 
 public abstract interface class io/rsocket/kotlin/metadata/MetadataReader {
 	public abstract fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public abstract fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
+	public abstract fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
 }
 
 public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata : io/rsocket/kotlin/metadata/Metadata {
@@ -483,8 +483,8 @@ public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMe
 
 public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata;
+	public synthetic fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadataKt {
@@ -502,15 +502,15 @@ public final class io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata : io
 
 public final class io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata;
+	public synthetic fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/RawMetadata : io/rsocket/kotlin/metadata/Metadata {
 	public static final field Companion Lio/rsocket/kotlin/metadata/RawMetadata$Companion;
-	public fun <init> (Lio/rsocket/kotlin/core/MimeType;Lkotlinx/io/Source;)V
+	public fun <init> (Lio/rsocket/kotlin/core/MimeType;Lkotlinx/io/Buffer;)V
 	public fun close ()V
-	public final fun getContent ()Lkotlinx/io/Source;
+	public final fun getContent ()Lkotlinx/io/Buffer;
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
 	public fun writeSelf (Lkotlinx/io/Sink;)V
 }
@@ -530,8 +530,8 @@ public final class io/rsocket/kotlin/metadata/RoutingMetadata : io/rsocket/kotli
 
 public final class io/rsocket/kotlin/metadata/RoutingMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/RoutingMetadata;
+	public synthetic fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/RoutingMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/RoutingMetadataKt {
@@ -565,8 +565,8 @@ public final class io/rsocket/kotlin/metadata/ZipkinTracingMetadata$Kind : java/
 
 public final class io/rsocket/kotlin/metadata/ZipkinTracingMetadata$Reader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/ZipkinTracingMetadata;
+	public synthetic fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/ZipkinTracingMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/ZipkinTracingMetadataKt {
@@ -586,9 +586,9 @@ public abstract interface class io/rsocket/kotlin/metadata/security/AuthMetadata
 
 public abstract interface class io/rsocket/kotlin/metadata/security/AuthMetadataReader : io/rsocket/kotlin/metadata/MetadataReader {
 	public fun getMimeType ()Lio/rsocket/kotlin/core/MimeType;
-	public synthetic fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/Metadata;
-	public fun read (Lkotlinx/io/Source;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public abstract fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public synthetic fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/Metadata;
+	public fun read (Lkotlinx/io/Buffer;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public abstract fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
 }
 
 public abstract interface class io/rsocket/kotlin/metadata/security/AuthType {
@@ -612,8 +612,8 @@ public final class io/rsocket/kotlin/metadata/security/BearerAuthMetadata : io/r
 }
 
 public final class io/rsocket/kotlin/metadata/security/BearerAuthMetadata$Reader : io/rsocket/kotlin/metadata/security/AuthMetadataReader {
-	public synthetic fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/BearerAuthMetadata;
+	public synthetic fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/BearerAuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/CustomAuthType : io/rsocket/kotlin/metadata/security/AuthTypeWithName {
@@ -629,16 +629,16 @@ public final class io/rsocket/kotlin/metadata/security/CustomAuthType : io/rsock
 
 public final class io/rsocket/kotlin/metadata/security/RawAuthMetadata : io/rsocket/kotlin/metadata/security/AuthMetadata {
 	public static final field Reader Lio/rsocket/kotlin/metadata/security/RawAuthMetadata$Reader;
-	public fun <init> (Lio/rsocket/kotlin/metadata/security/AuthType;Lkotlinx/io/Source;)V
+	public fun <init> (Lio/rsocket/kotlin/metadata/security/AuthType;Lkotlinx/io/Buffer;)V
 	public fun close ()V
-	public final fun getContent ()Lkotlinx/io/Source;
+	public final fun getContent ()Lkotlinx/io/Buffer;
 	public fun getType ()Lio/rsocket/kotlin/metadata/security/AuthType;
 	public fun writeContent (Lkotlinx/io/Sink;)V
 }
 
 public final class io/rsocket/kotlin/metadata/security/RawAuthMetadata$Reader : io/rsocket/kotlin/metadata/security/AuthMetadataReader {
-	public synthetic fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;
+	public synthetic fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/RawAuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/RawAuthMetadataKt {
@@ -669,8 +669,8 @@ public final class io/rsocket/kotlin/metadata/security/SimpleAuthMetadata : io/r
 }
 
 public final class io/rsocket/kotlin/metadata/security/SimpleAuthMetadata$Reader : io/rsocket/kotlin/metadata/security/AuthMetadataReader {
-	public synthetic fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
-	public fun readContent (Lkotlinx/io/Source;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/SimpleAuthMetadata;
+	public synthetic fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/AuthMetadata;
+	public fun readContent (Lkotlinx/io/Buffer;Lio/rsocket/kotlin/metadata/security/AuthType;)Lio/rsocket/kotlin/metadata/security/SimpleAuthMetadata;
 }
 
 public final class io/rsocket/kotlin/metadata/security/WellKnowAuthType : java/lang/Enum, io/rsocket/kotlin/metadata/security/AuthTypeWithId, io/rsocket/kotlin/metadata/security/AuthTypeWithName {

--- a/rsocket-core/api/rsocket-core.klib.api
+++ b/rsocket-core/api/rsocket-core.klib.api
@@ -156,7 +156,7 @@ abstract interface <#A: io.rsocket.kotlin.metadata/Metadata> io.rsocket.kotlin.m
     abstract val mimeType // io.rsocket.kotlin.metadata/MetadataReader.mimeType|{}mimeType[0]
         abstract fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/MetadataReader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-    abstract fun (kotlinx.io/Source).read(): #A // io.rsocket.kotlin.metadata/MetadataReader.read|read@kotlinx.io.Source(){}[0]
+    abstract fun (kotlinx.io/Buffer).read(): #A // io.rsocket.kotlin.metadata/MetadataReader.read|read@kotlinx.io.Buffer(){}[0]
 }
 
 abstract interface <#A: io.rsocket.kotlin.transport/RSocketServerInstance> io.rsocket.kotlin.transport/RSocketServerTarget : kotlinx.coroutines/CoroutineScope { // io.rsocket.kotlin.transport/RSocketServerTarget|null[0]
@@ -237,8 +237,8 @@ sealed interface <#A: io.rsocket.kotlin.metadata.security/AuthMetadata> io.rsock
     open val mimeType // io.rsocket.kotlin.metadata.security/AuthMetadataReader.mimeType|{}mimeType[0]
         open fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata.security/AuthMetadataReader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-    abstract fun (kotlinx.io/Source).readContent(io.rsocket.kotlin.metadata.security/AuthType): #A // io.rsocket.kotlin.metadata.security/AuthMetadataReader.readContent|readContent@kotlinx.io.Source(io.rsocket.kotlin.metadata.security.AuthType){}[0]
-    open fun (kotlinx.io/Source).read(): #A // io.rsocket.kotlin.metadata.security/AuthMetadataReader.read|read@kotlinx.io.Source(){}[0]
+    abstract fun (kotlinx.io/Buffer).readContent(io.rsocket.kotlin.metadata.security/AuthType): #A // io.rsocket.kotlin.metadata.security/AuthMetadataReader.readContent|readContent@kotlinx.io.Buffer(io.rsocket.kotlin.metadata.security.AuthType){}[0]
+    open fun (kotlinx.io/Buffer).read(): #A // io.rsocket.kotlin.metadata.security/AuthMetadataReader.read|read@kotlinx.io.Buffer(){}[0]
 }
 
 sealed interface io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.core/MimeType|null[0]
@@ -298,7 +298,7 @@ sealed interface io.rsocket.kotlin.metadata/CompositeMetadata : io.rsocket.kotli
         final val mimeType // io.rsocket.kotlin.metadata/CompositeMetadata.Reader.mimeType|{}mimeType[0]
             final fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/CompositeMetadata.Reader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-        final fun (kotlinx.io/Source).read(): io.rsocket.kotlin.metadata/CompositeMetadata // io.rsocket.kotlin.metadata/CompositeMetadata.Reader.read|read@kotlinx.io.Source(){}[0]
+        final fun (kotlinx.io/Buffer).read(): io.rsocket.kotlin.metadata/CompositeMetadata // io.rsocket.kotlin.metadata/CompositeMetadata.Reader.read|read@kotlinx.io.Buffer(){}[0]
     }
 }
 
@@ -457,7 +457,7 @@ final class io.rsocket.kotlin.metadata.security/BearerAuthMetadata : io.rsocket.
     final fun close() // io.rsocket.kotlin.metadata.security/BearerAuthMetadata.close|close(){}[0]
 
     final object Reader : io.rsocket.kotlin.metadata.security/AuthMetadataReader<io.rsocket.kotlin.metadata.security/BearerAuthMetadata> { // io.rsocket.kotlin.metadata.security/BearerAuthMetadata.Reader|null[0]
-        final fun (kotlinx.io/Source).readContent(io.rsocket.kotlin.metadata.security/AuthType): io.rsocket.kotlin.metadata.security/BearerAuthMetadata // io.rsocket.kotlin.metadata.security/BearerAuthMetadata.Reader.readContent|readContent@kotlinx.io.Source(io.rsocket.kotlin.metadata.security.AuthType){}[0]
+        final fun (kotlinx.io/Buffer).readContent(io.rsocket.kotlin.metadata.security/AuthType): io.rsocket.kotlin.metadata.security/BearerAuthMetadata // io.rsocket.kotlin.metadata.security/BearerAuthMetadata.Reader.readContent|readContent@kotlinx.io.Buffer(io.rsocket.kotlin.metadata.security.AuthType){}[0]
     }
 }
 
@@ -475,10 +475,10 @@ final class io.rsocket.kotlin.metadata.security/CustomAuthType : io.rsocket.kotl
 }
 
 final class io.rsocket.kotlin.metadata.security/RawAuthMetadata : io.rsocket.kotlin.metadata.security/AuthMetadata { // io.rsocket.kotlin.metadata.security/RawAuthMetadata|null[0]
-    constructor <init>(io.rsocket.kotlin.metadata.security/AuthType, kotlinx.io/Source) // io.rsocket.kotlin.metadata.security/RawAuthMetadata.<init>|<init>(io.rsocket.kotlin.metadata.security.AuthType;kotlinx.io.Source){}[0]
+    constructor <init>(io.rsocket.kotlin.metadata.security/AuthType, kotlinx.io/Buffer) // io.rsocket.kotlin.metadata.security/RawAuthMetadata.<init>|<init>(io.rsocket.kotlin.metadata.security.AuthType;kotlinx.io.Buffer){}[0]
 
     final val content // io.rsocket.kotlin.metadata.security/RawAuthMetadata.content|{}content[0]
-        final fun <get-content>(): kotlinx.io/Source // io.rsocket.kotlin.metadata.security/RawAuthMetadata.content.<get-content>|<get-content>(){}[0]
+        final fun <get-content>(): kotlinx.io/Buffer // io.rsocket.kotlin.metadata.security/RawAuthMetadata.content.<get-content>|<get-content>(){}[0]
     final val type // io.rsocket.kotlin.metadata.security/RawAuthMetadata.type|{}type[0]
         final fun <get-type>(): io.rsocket.kotlin.metadata.security/AuthType // io.rsocket.kotlin.metadata.security/RawAuthMetadata.type.<get-type>|<get-type>(){}[0]
 
@@ -486,7 +486,7 @@ final class io.rsocket.kotlin.metadata.security/RawAuthMetadata : io.rsocket.kot
     final fun close() // io.rsocket.kotlin.metadata.security/RawAuthMetadata.close|close(){}[0]
 
     final object Reader : io.rsocket.kotlin.metadata.security/AuthMetadataReader<io.rsocket.kotlin.metadata.security/RawAuthMetadata> { // io.rsocket.kotlin.metadata.security/RawAuthMetadata.Reader|null[0]
-        final fun (kotlinx.io/Source).readContent(io.rsocket.kotlin.metadata.security/AuthType): io.rsocket.kotlin.metadata.security/RawAuthMetadata // io.rsocket.kotlin.metadata.security/RawAuthMetadata.Reader.readContent|readContent@kotlinx.io.Source(io.rsocket.kotlin.metadata.security.AuthType){}[0]
+        final fun (kotlinx.io/Buffer).readContent(io.rsocket.kotlin.metadata.security/AuthType): io.rsocket.kotlin.metadata.security/RawAuthMetadata // io.rsocket.kotlin.metadata.security/RawAuthMetadata.Reader.readContent|readContent@kotlinx.io.Buffer(io.rsocket.kotlin.metadata.security.AuthType){}[0]
     }
 }
 
@@ -517,7 +517,7 @@ final class io.rsocket.kotlin.metadata.security/SimpleAuthMetadata : io.rsocket.
     final fun close() // io.rsocket.kotlin.metadata.security/SimpleAuthMetadata.close|close(){}[0]
 
     final object Reader : io.rsocket.kotlin.metadata.security/AuthMetadataReader<io.rsocket.kotlin.metadata.security/SimpleAuthMetadata> { // io.rsocket.kotlin.metadata.security/SimpleAuthMetadata.Reader|null[0]
-        final fun (kotlinx.io/Source).readContent(io.rsocket.kotlin.metadata.security/AuthType): io.rsocket.kotlin.metadata.security/SimpleAuthMetadata // io.rsocket.kotlin.metadata.security/SimpleAuthMetadata.Reader.readContent|readContent@kotlinx.io.Source(io.rsocket.kotlin.metadata.security.AuthType){}[0]
+        final fun (kotlinx.io/Buffer).readContent(io.rsocket.kotlin.metadata.security/AuthType): io.rsocket.kotlin.metadata.security/SimpleAuthMetadata // io.rsocket.kotlin.metadata.security/SimpleAuthMetadata.Reader.readContent|readContent@kotlinx.io.Buffer(io.rsocket.kotlin.metadata.security.AuthType){}[0]
     }
 }
 
@@ -546,7 +546,7 @@ final class io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata 
         final val mimeType // io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata.Reader.mimeType|{}mimeType[0]
             final fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata.Reader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-        final fun (kotlinx.io/Source).read(): io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata // io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata.Reader.read|read@kotlinx.io.Source(){}[0]
+        final fun (kotlinx.io/Buffer).read(): io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata // io.rsocket.kotlin.metadata/PerStreamAcceptableDataMimeTypesMetadata.Reader.read|read@kotlinx.io.Buffer(){}[0]
     }
 }
 
@@ -565,15 +565,15 @@ final class io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata : io.rsocke
         final val mimeType // io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata.Reader.mimeType|{}mimeType[0]
             final fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata.Reader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-        final fun (kotlinx.io/Source).read(): io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata // io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata.Reader.read|read@kotlinx.io.Source(){}[0]
+        final fun (kotlinx.io/Buffer).read(): io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata // io.rsocket.kotlin.metadata/PerStreamDataMimeTypeMetadata.Reader.read|read@kotlinx.io.Buffer(){}[0]
     }
 }
 
 final class io.rsocket.kotlin.metadata/RawMetadata : io.rsocket.kotlin.metadata/Metadata { // io.rsocket.kotlin.metadata/RawMetadata|null[0]
-    constructor <init>(io.rsocket.kotlin.core/MimeType, kotlinx.io/Source) // io.rsocket.kotlin.metadata/RawMetadata.<init>|<init>(io.rsocket.kotlin.core.MimeType;kotlinx.io.Source){}[0]
+    constructor <init>(io.rsocket.kotlin.core/MimeType, kotlinx.io/Buffer) // io.rsocket.kotlin.metadata/RawMetadata.<init>|<init>(io.rsocket.kotlin.core.MimeType;kotlinx.io.Buffer){}[0]
 
     final val content // io.rsocket.kotlin.metadata/RawMetadata.content|{}content[0]
-        final fun <get-content>(): kotlinx.io/Source // io.rsocket.kotlin.metadata/RawMetadata.content.<get-content>|<get-content>(){}[0]
+        final fun <get-content>(): kotlinx.io/Buffer // io.rsocket.kotlin.metadata/RawMetadata.content.<get-content>|<get-content>(){}[0]
     final val mimeType // io.rsocket.kotlin.metadata/RawMetadata.mimeType|{}mimeType[0]
         final fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/RawMetadata.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
@@ -600,7 +600,7 @@ final class io.rsocket.kotlin.metadata/RoutingMetadata : io.rsocket.kotlin.metad
         final val mimeType // io.rsocket.kotlin.metadata/RoutingMetadata.Reader.mimeType|{}mimeType[0]
             final fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/RoutingMetadata.Reader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-        final fun (kotlinx.io/Source).read(): io.rsocket.kotlin.metadata/RoutingMetadata // io.rsocket.kotlin.metadata/RoutingMetadata.Reader.read|read@kotlinx.io.Source(){}[0]
+        final fun (kotlinx.io/Buffer).read(): io.rsocket.kotlin.metadata/RoutingMetadata // io.rsocket.kotlin.metadata/RoutingMetadata.Reader.read|read@kotlinx.io.Buffer(){}[0]
     }
 }
 
@@ -644,7 +644,7 @@ final class io.rsocket.kotlin.metadata/ZipkinTracingMetadata : io.rsocket.kotlin
         final val mimeType // io.rsocket.kotlin.metadata/ZipkinTracingMetadata.Reader.mimeType|{}mimeType[0]
             final fun <get-mimeType>(): io.rsocket.kotlin.core/MimeType // io.rsocket.kotlin.metadata/ZipkinTracingMetadata.Reader.mimeType.<get-mimeType>|<get-mimeType>(){}[0]
 
-        final fun (kotlinx.io/Source).read(): io.rsocket.kotlin.metadata/ZipkinTracingMetadata // io.rsocket.kotlin.metadata/ZipkinTracingMetadata.Reader.read|read@kotlinx.io.Source(){}[0]
+        final fun (kotlinx.io/Buffer).read(): io.rsocket.kotlin.metadata/ZipkinTracingMetadata // io.rsocket.kotlin.metadata/ZipkinTracingMetadata.Reader.read|read@kotlinx.io.Buffer(){}[0]
     }
 }
 
@@ -715,7 +715,7 @@ final class io.rsocket.kotlin/PrefetchStrategy : io.rsocket.kotlin/RequestStrate
 
 final class io.rsocket.kotlin/RSocketRequestHandlerBuilder { // io.rsocket.kotlin/RSocketRequestHandlerBuilder|null[0]
     final fun fireAndForget(kotlin.coroutines/SuspendFunction2<io.rsocket.kotlin/RSocket, io.rsocket.kotlin.payload/Payload, kotlin/Unit>) // io.rsocket.kotlin/RSocketRequestHandlerBuilder.fireAndForget|fireAndForget(kotlin.coroutines.SuspendFunction2<io.rsocket.kotlin.RSocket,io.rsocket.kotlin.payload.Payload,kotlin.Unit>){}[0]
-    final fun metadataPush(kotlin.coroutines/SuspendFunction2<io.rsocket.kotlin/RSocket, kotlinx.io/Source, kotlin/Unit>) // io.rsocket.kotlin/RSocketRequestHandlerBuilder.metadataPush|metadataPush(kotlin.coroutines.SuspendFunction2<io.rsocket.kotlin.RSocket,kotlinx.io.Source,kotlin.Unit>){}[0]
+    final fun metadataPush(kotlin.coroutines/SuspendFunction2<io.rsocket.kotlin/RSocket, kotlinx.io/Buffer, kotlin/Unit>) // io.rsocket.kotlin/RSocketRequestHandlerBuilder.metadataPush|metadataPush(kotlin.coroutines.SuspendFunction2<io.rsocket.kotlin.RSocket,kotlinx.io.Buffer,kotlin.Unit>){}[0]
     final fun requestChannel(kotlin.coroutines/SuspendFunction3<io.rsocket.kotlin/RSocket, io.rsocket.kotlin.payload/Payload, kotlinx.coroutines.flow/Flow<io.rsocket.kotlin.payload/Payload>, kotlinx.coroutines.flow/Flow<io.rsocket.kotlin.payload/Payload>>) // io.rsocket.kotlin/RSocketRequestHandlerBuilder.requestChannel|requestChannel(kotlin.coroutines.SuspendFunction3<io.rsocket.kotlin.RSocket,io.rsocket.kotlin.payload.Payload,kotlinx.coroutines.flow.Flow<io.rsocket.kotlin.payload.Payload>,kotlinx.coroutines.flow.Flow<io.rsocket.kotlin.payload.Payload>>){}[0]
     final fun requestResponse(kotlin.coroutines/SuspendFunction2<io.rsocket.kotlin/RSocket, io.rsocket.kotlin.payload/Payload, io.rsocket.kotlin.payload/Payload>) // io.rsocket.kotlin/RSocketRequestHandlerBuilder.requestResponse|requestResponse(kotlin.coroutines.SuspendFunction2<io.rsocket.kotlin.RSocket,io.rsocket.kotlin.payload.Payload,io.rsocket.kotlin.payload.Payload>){}[0]
     final fun requestStream(kotlin.coroutines/SuspendFunction2<io.rsocket.kotlin/RSocket, io.rsocket.kotlin.payload/Payload, kotlinx.coroutines.flow/Flow<io.rsocket.kotlin.payload/Payload>>) // io.rsocket.kotlin/RSocketRequestHandlerBuilder.requestStream|requestStream(kotlin.coroutines.SuspendFunction2<io.rsocket.kotlin.RSocket,io.rsocket.kotlin.payload.Payload,kotlinx.coroutines.flow.Flow<io.rsocket.kotlin.payload.Payload>>){}[0]
@@ -793,9 +793,9 @@ final object io.rsocket.kotlin.logging/NoopLogger : io.rsocket.kotlin.logging/Lo
 final fun (io.rsocket.kotlin.metadata.security/RawAuthMetadata).io.rsocket.kotlin.metadata.security/hasAuthTypeOf(io.rsocket.kotlin.metadata.security/AuthMetadataReader<*>): kotlin/Boolean // io.rsocket.kotlin.metadata.security/hasAuthTypeOf|hasAuthTypeOf@io.rsocket.kotlin.metadata.security.RawAuthMetadata(io.rsocket.kotlin.metadata.security.AuthMetadataReader<*>){}[0]
 final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/contains(io.rsocket.kotlin.core/MimeType): kotlin/Boolean // io.rsocket.kotlin.metadata/contains|contains@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
 final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/contains(io.rsocket.kotlin.metadata/MetadataReader<*>): kotlin/Boolean // io.rsocket.kotlin.metadata/contains|contains@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.metadata.MetadataReader<*>){}[0]
-final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/get(io.rsocket.kotlin.core/MimeType): kotlinx.io/Source // io.rsocket.kotlin.metadata/get|get@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
-final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/getOrNull(io.rsocket.kotlin.core/MimeType): kotlinx.io/Source? // io.rsocket.kotlin.metadata/getOrNull|getOrNull@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
-final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/list(io.rsocket.kotlin.core/MimeType): kotlin.collections/List<kotlinx.io/Source> // io.rsocket.kotlin.metadata/list|list@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
+final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/get(io.rsocket.kotlin.core/MimeType): kotlinx.io/Buffer // io.rsocket.kotlin.metadata/get|get@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
+final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/getOrNull(io.rsocket.kotlin.core/MimeType): kotlinx.io/Buffer? // io.rsocket.kotlin.metadata/getOrNull|getOrNull@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
+final fun (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/list(io.rsocket.kotlin.core/MimeType): kotlin.collections/List<kotlinx.io/Buffer> // io.rsocket.kotlin.metadata/list|list@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.core.MimeType){}[0]
 final fun (io.rsocket.kotlin.metadata/CompositeMetadata.Entry).io.rsocket.kotlin.metadata/hasMimeTypeOf(io.rsocket.kotlin.metadata/MetadataReader<*>): kotlin/Boolean // io.rsocket.kotlin.metadata/hasMimeTypeOf|hasMimeTypeOf@io.rsocket.kotlin.metadata.CompositeMetadata.Entry(io.rsocket.kotlin.metadata.MetadataReader<*>){}[0]
 final fun (io.rsocket.kotlin.metadata/Metadata).io.rsocket.kotlin.metadata/toBuffer(): kotlinx.io/Buffer // io.rsocket.kotlin.metadata/toBuffer|toBuffer@io.rsocket.kotlin.metadata.Metadata(){}[0]
 final fun (io.rsocket.kotlin.payload/PayloadBuilder).io.rsocket.kotlin.metadata/metadata(io.rsocket.kotlin.metadata/Metadata) // io.rsocket.kotlin.metadata/metadata|metadata@io.rsocket.kotlin.payload.PayloadBuilder(io.rsocket.kotlin.metadata.Metadata){}[0]
@@ -810,7 +810,7 @@ final fun <#A: io.rsocket.kotlin.metadata/Metadata> (io.rsocket.kotlin.metadata/
 final fun <#A: io.rsocket.kotlin.metadata/Metadata> (io.rsocket.kotlin.metadata/CompositeMetadata).io.rsocket.kotlin.metadata/list(io.rsocket.kotlin.metadata/MetadataReader<#A>): kotlin.collections/List<#A> // io.rsocket.kotlin.metadata/list|list@io.rsocket.kotlin.metadata.CompositeMetadata(io.rsocket.kotlin.metadata.MetadataReader<0:0>){0§<io.rsocket.kotlin.metadata.Metadata>}[0]
 final fun <#A: io.rsocket.kotlin.metadata/Metadata> (io.rsocket.kotlin.metadata/CompositeMetadata.Entry).io.rsocket.kotlin.metadata/read(io.rsocket.kotlin.metadata/MetadataReader<#A>): #A // io.rsocket.kotlin.metadata/read|read@io.rsocket.kotlin.metadata.CompositeMetadata.Entry(io.rsocket.kotlin.metadata.MetadataReader<0:0>){0§<io.rsocket.kotlin.metadata.Metadata>}[0]
 final fun <#A: io.rsocket.kotlin.metadata/Metadata> (io.rsocket.kotlin.metadata/CompositeMetadata.Entry).io.rsocket.kotlin.metadata/readOrNull(io.rsocket.kotlin.metadata/MetadataReader<#A>): #A? // io.rsocket.kotlin.metadata/readOrNull|readOrNull@io.rsocket.kotlin.metadata.CompositeMetadata.Entry(io.rsocket.kotlin.metadata.MetadataReader<0:0>){0§<io.rsocket.kotlin.metadata.Metadata>}[0]
-final fun <#A: io.rsocket.kotlin.metadata/Metadata> (kotlinx.io/Source).io.rsocket.kotlin.metadata/read(io.rsocket.kotlin.metadata/MetadataReader<#A>): #A // io.rsocket.kotlin.metadata/read|read@kotlinx.io.Source(io.rsocket.kotlin.metadata.MetadataReader<0:0>){0§<io.rsocket.kotlin.metadata.Metadata>}[0]
+final fun <#A: io.rsocket.kotlin.metadata/Metadata> (kotlinx.io/Buffer).io.rsocket.kotlin.metadata/read(io.rsocket.kotlin.metadata/MetadataReader<#A>): #A // io.rsocket.kotlin.metadata/read|read@kotlinx.io.Buffer(io.rsocket.kotlin.metadata.MetadataReader<0:0>){0§<io.rsocket.kotlin.metadata.Metadata>}[0]
 final fun io.rsocket.kotlin.core/RSocketConnector(kotlin/Function1<io.rsocket.kotlin.core/RSocketConnectorBuilder, kotlin/Unit> = ...): io.rsocket.kotlin.core/RSocketConnector // io.rsocket.kotlin.core/RSocketConnector|RSocketConnector(kotlin.Function1<io.rsocket.kotlin.core.RSocketConnectorBuilder,kotlin.Unit>){}[0]
 final fun io.rsocket.kotlin.core/RSocketServer(kotlin/Function1<io.rsocket.kotlin.core/RSocketServerBuilder, kotlin/Unit> = ...): io.rsocket.kotlin.core/RSocketServer // io.rsocket.kotlin.core/RSocketServer|RSocketServer(kotlin.Function1<io.rsocket.kotlin.core.RSocketServerBuilder,kotlin.Unit>){}[0]
 final fun io.rsocket.kotlin.keepalive/KeepAlive(kotlin.time/Duration = ..., kotlin.time/Duration = ...): io.rsocket.kotlin.keepalive/KeepAlive // io.rsocket.kotlin.keepalive/KeepAlive|KeepAlive(kotlin.time.Duration;kotlin.time.Duration){}[0]

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketRequestHandler.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/RSocketRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public class RSocketRequestHandlerBuilder internal constructor() {
     private var requestChannel: (suspend RSocket.(initPayload: Payload, payloads: Flow<Payload>) -> Flow<Payload>)? =
         null
 
-    public fun metadataPush(block: (suspend RSocket.(metadata: Source) -> Unit)) {
+    public fun metadataPush(block: (suspend RSocket.(metadata: Buffer) -> Unit)) {
         check(metadataPush == null) { "Metadata Push handler already configured" }
         metadataPush = block
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ErrorFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ internal class ErrorFrame(
     }
 }
 
-internal fun Source.readError(streamId: Int): ErrorFrame {
+internal fun Buffer.readError(streamId: Int): ErrorFrame {
     val errorCode = readInt()
     val message = readString()
     return ErrorFrame(streamId, RSocketError(streamId, errorCode, message))

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ExtensionFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ internal class ExtensionFrame(
     }
 }
 
-internal fun Source.readExtension(streamId: Int, flags: Int): ExtensionFrame {
+internal fun Buffer.readExtension(streamId: Int, flags: Int): ExtensionFrame {
     val extendedType = readInt()
     val payload = readPayload(flags)
     return ExtensionFrame(streamId, extendedType, payload)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/KeepAliveFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ internal class KeepAliveFrame(
     }
 }
 
-internal fun Source.readKeepAlive(flags: Int): KeepAliveFrame {
+internal fun Buffer.readKeepAlive(flags: Int): KeepAliveFrame {
     val respond = flags check RespondFlag
     val lastPosition = readLong()
     val data = readBuffer()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/LeaseFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ internal class LeaseFrame(
     }
 }
 
-internal fun Source.readLease(flags: Int): LeaseFrame {
+internal fun Buffer.readLease(flags: Int): LeaseFrame {
     val ttl = readInt()
     val numberOfRequests = readInt()
     val metadata = if (flags check Flags.Metadata) readMetadata() else null

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/MetadataPushFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,5 +43,5 @@ internal class MetadataPushFrame(
     }
 }
 
-internal fun Source.readMetadataPush(): MetadataPushFrame =
+internal fun Buffer.readMetadataPush(): MetadataPushFrame =
     MetadataPushFrame(readBuffer())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestFrame.kt
@@ -63,7 +63,7 @@ internal class RequestFrame(
     }
 }
 
-internal fun Source.readRequest(
+internal fun Buffer.readRequest(
     type: FrameType,
     streamId: Int,
     flags: Int,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/RequestNFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ internal class RequestNFrame(
     }
 }
 
-internal fun Source.readRequestN(streamId: Int): RequestNFrame {
+internal fun Buffer.readRequestN(streamId: Int): RequestNFrame {
     val requestN = readInt()
     return RequestNFrame(streamId, requestN)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ internal class ResumeFrame(
     }
 }
 
-internal fun Source.readResume(): ResumeFrame {
+internal fun Buffer.readResume(): ResumeFrame {
     val version = readVersion()
     val resumeToken = readResumeToken()
     val lastReceivedServerPosition = readLong()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/ResumeOkFrame.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,4 +38,4 @@ internal class ResumeOkFrame(
     }
 }
 
-internal fun Source.readResumeOk(): ResumeOkFrame = ResumeOkFrame(readLong())
+internal fun Buffer.readResumeOk(): ResumeOkFrame = ResumeOkFrame(readLong())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/SetupFrame.kt
@@ -74,7 +74,7 @@ internal class SetupFrame(
     }
 }
 
-internal fun Source.readSetup(flags: Int): SetupFrame {
+internal fun Buffer.readSetup(flags: Int): SetupFrame {
     val version = readVersion()
     val keepAlive = run {
         val interval = readInt()
@@ -98,7 +98,7 @@ internal fun Source.readSetup(flags: Int): SetupFrame {
     )
 }
 
-private fun Source.readStringMimeType(): String {
+private fun Buffer.readStringMimeType(): String {
     val length = readByte().toLong()
     return readString(length)
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/Version.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ internal class Version(val major: Int, val minor: Int) {
     }
 }
 
-internal fun Source.readVersion(): Version {
+internal fun Buffer.readVersion(): Version {
     val value = readInt()
     return Version(
         major = value shr 16 and 0xFFFF,

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/mimeType.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/mimeType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ internal fun Sink.writeMimeType(type: MimeType) {
     }
 }
 
-internal fun Source.readMimeType(): MimeType = readType(
+internal fun Buffer.readMimeType(): MimeType = readType(
     { WellKnownMimeType(it) ?: ReservedMimeType(it) },
     { WellKnownMimeType(it) ?: CustomMimeType(it) }
 )
@@ -40,7 +40,7 @@ internal fun Sink.writeAuthType(type: AuthType) {
     }
 }
 
-internal fun Source.readAuthType(): AuthType = readType(
+internal fun Buffer.readAuthType(): AuthType = readType(
     { WellKnowAuthType(it) ?: ReservedAuthType(it) },
     { WellKnowAuthType(it) ?: CustomAuthType(it) }
 )
@@ -62,7 +62,7 @@ private fun Sink.writeIdentifier(identifier: Byte) {
     writeByte(identifier or KnownTypeFlag)
 }
 
-private inline fun <T> Source.readType(
+private inline fun <T> Buffer.readType(
     fromIdentifier: (Byte) -> T,
     fromText: (String) -> T,
 ): T {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/payload.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import io.rsocket.kotlin.internal.io.*
 import io.rsocket.kotlin.payload.*
 import kotlinx.io.*
 
-internal fun Source.readMetadata(): Buffer {
+internal fun Buffer.readMetadata(): Buffer {
     val length = readInt24()
     return readBuffer(length)
 }
@@ -32,7 +32,7 @@ internal fun Sink.writeMetadata(metadata: Buffer?) {
     }
 }
 
-internal fun Source.readPayload(flags: Int): Payload {
+internal fun Buffer.readPayload(flags: Int): Payload {
     val metadata = if (flags check Flags.Metadata) readMetadata() else null
     val data = readBuffer()
     return Payload(data = data, metadata = metadata)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/frame/io/util.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.rsocket.kotlin.frame.io
 
 import kotlinx.io.*
 
-internal fun Source.readResumeToken(): Buffer {
+internal fun Buffer.readResumeToken(): Buffer {
     val length = readShort().toInt() and 0xFFFF
     return readBuffer(length)
 }
@@ -30,11 +30,11 @@ internal fun Sink.writeResumeToken(resumeToken: Buffer?) {
     }
 }
 
-internal fun Source.readBuffer(): Buffer {
+internal fun Buffer.readBuffer(): Buffer {
     return Buffer().also(this::transferTo)
 }
 
-internal fun Source.readBuffer(length: Int): Buffer {
+internal fun Buffer.readBuffer(length: Int): Buffer {
     val output = Buffer()
     output.write(this, length.toLong())
     return output

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public sealed interface CompositeMetadata : Metadata {
 
     public companion object Reader : MetadataReader<CompositeMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketCompositeMetadata
-        override fun Source.read(): CompositeMetadata {
+        override fun Buffer.read(): CompositeMetadata {
             val list = mutableListOf<Entry>()
             while (!exhausted()) {
                 val type = readMimeType()

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/CompositeMetadataExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,17 +47,17 @@ public operator fun CompositeMetadata.contains(mimeType: MimeType): Boolean {
 }
 
 @ExperimentalMetadataApi
-public operator fun CompositeMetadata.get(mimeType: MimeType): Source {
+public operator fun CompositeMetadata.get(mimeType: MimeType): Buffer {
     return entries.first { it.mimeType == mimeType }.content
 }
 
 @ExperimentalMetadataApi
-public fun CompositeMetadata.getOrNull(mimeType: MimeType): Source? {
+public fun CompositeMetadata.getOrNull(mimeType: MimeType): Buffer? {
     return entries.find { it.mimeType == mimeType }?.content
 }
 
 @ExperimentalMetadataApi
-public fun CompositeMetadata.list(mimeType: MimeType): List<Source> {
+public fun CompositeMetadata.list(mimeType: MimeType): List<Buffer> {
     return entries.mapNotNull { if (it.mimeType == mimeType) it.content else null }
 }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/Metadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public interface Metadata : AutoCloseable {
 @ExperimentalMetadataApi
 public interface MetadataReader<M : Metadata> {
     public val mimeType: MimeType
-    public fun Source.read(): M
+    public fun Buffer.read(): M
 }
 
 
@@ -38,7 +38,7 @@ public interface MetadataReader<M : Metadata> {
 public fun PayloadBuilder.metadata(metadata: Metadata): Unit = metadata(metadata.toBuffer())
 
 @ExperimentalMetadataApi
-public fun <M : Metadata> Source.read(
+public fun <M : Metadata> Buffer.read(
     reader: MetadataReader<M>,
 ): M = use {
     with(reader) { read() }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamAcceptableDataMimeTypesMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class PerStreamAcceptableDataMimeTypesMetadata(public val types: List<Mim
 
     public companion object Reader : MetadataReader<PerStreamAcceptableDataMimeTypesMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAcceptMimeTypes
-        override fun Source.read(): PerStreamAcceptableDataMimeTypesMetadata {
+        override fun Buffer.read(): PerStreamAcceptableDataMimeTypesMetadata {
             val list = mutableListOf<MimeType>()
             while (!exhausted()) list.add(readMimeType())
             return PerStreamAcceptableDataMimeTypesMetadata(list.toList())

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/PerStreamDataMimeTypeMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class PerStreamDataMimeTypeMetadata(public val type: MimeType) : Metadata
 
     public companion object Reader : MetadataReader<PerStreamDataMimeTypeMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketMimeType
-        override fun Source.read(): PerStreamDataMimeTypeMetadata =
+        override fun Buffer.read(): PerStreamDataMimeTypeMetadata =
             PerStreamDataMimeTypeMetadata(readMimeType())
     }
 }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RawMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import kotlinx.io.*
 @ExperimentalMetadataApi
 public class RawMetadata(
     override val mimeType: MimeType,
-    public val content: Source,
+    public val content: Buffer,
 ) : Metadata {
     override fun Sink.writeSelf() {
         transferFrom(content)
@@ -35,7 +35,7 @@ public class RawMetadata(
     }
 
     private class Reader(override val mimeType: MimeType) : MetadataReader<RawMetadata> {
-        override fun Source.read(): RawMetadata =
+        override fun Buffer.read(): RawMetadata =
             RawMetadata(mimeType, readBuffer())
     }
 

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/RoutingMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class RoutingMetadata(public val tags: List<String>) : Metadata {
 
     public companion object Reader : MetadataReader<RoutingMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketRouting
-        override fun Source.read(): RoutingMetadata {
+        override fun Buffer.read(): RoutingMetadata {
             val list = mutableListOf<String>()
             while (!exhausted()) {
                 val length = readByte().toLong() and 0xFF

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/ZipkinTracingMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class ZipkinTracingMetadata internal constructor(
 
     public companion object Reader : MetadataReader<ZipkinTracingMetadata> {
         override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketTracingZipkin
-        override fun Source.read(): ZipkinTracingMetadata {
+        override fun Buffer.read(): ZipkinTracingMetadata {
             val flags = readByte()
 
             val kind = when {

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/AuthMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ public sealed interface AuthMetadata : Metadata {
 
 @ExperimentalMetadataApi
 public sealed interface AuthMetadataReader<AM : AuthMetadata> : MetadataReader<AM> {
-    public fun Source.readContent(type: AuthType): AM
+    public fun Buffer.readContent(type: AuthType): AM
 
     override val mimeType: MimeType get() = WellKnownMimeType.MessageRSocketAuthentication
-    override fun Source.read(): AM {
+    override fun Buffer.read(): AM {
         val type = readAuthType()
         return readContent(type)
     }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/BearerAuthMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class BearerAuthMetadata(
     override fun close(): Unit = Unit
 
     public companion object Reader : AuthMetadataReader<BearerAuthMetadata> {
-        override fun Source.readContent(type: AuthType): BearerAuthMetadata {
+        override fun Buffer.readContent(type: AuthType): BearerAuthMetadata {
             require(type == WellKnowAuthType.Bearer) { "Metadata auth type should be 'bearer'" }
             val token = readString()
             return BearerAuthMetadata(token)

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/RawAuthMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import kotlinx.io.*
 @ExperimentalMetadataApi
 public class RawAuthMetadata(
     public override val type: AuthType,
-    public val content: Source,
+    public val content: Buffer,
 ) : AuthMetadata {
 
     override fun Sink.writeContent() {
@@ -35,7 +35,7 @@ public class RawAuthMetadata(
     }
 
     public companion object Reader : AuthMetadataReader<RawAuthMetadata> {
-        override fun Source.readContent(type: AuthType): RawAuthMetadata {
+        override fun Buffer.readContent(type: AuthType): RawAuthMetadata {
             val content = readBuffer()
             return RawAuthMetadata(type, content)
         }

--- a/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
+++ b/rsocket-core/src/commonMain/kotlin/io/rsocket/kotlin/metadata/security/SimpleAuthMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class SimpleAuthMetadata(
     override fun close(): Unit = Unit
 
     public companion object Reader : AuthMetadataReader<SimpleAuthMetadata> {
-        override fun Source.readContent(type: AuthType): SimpleAuthMetadata {
+        override fun Buffer.readContent(type: AuthType): SimpleAuthMetadata {
             require(type == WellKnowAuthType.Simple) { "Metadata auth type should be 'simple'" }
             val length = readShort().toLong()
             val username = readString(length)

--- a/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/transport/internal/PrioritizationFrameQueueTest.kt
+++ b/rsocket-core/src/commonTest/kotlin/io/rsocket/kotlin/transport/internal/PrioritizationFrameQueueTest.kt
@@ -61,7 +61,7 @@ class PrioritizationFrameQueueTest : SuspendTest {
 
     @Test
     fun testAsyncReceive() = test {
-        val deferred = CompletableDeferred<Source?>()
+        val deferred = CompletableDeferred<Buffer?>()
         launch(Dispatchers.IoCompatible) {
             deferred.complete(queue.dequeueFrame())
         }


### PR DESCRIPTION
### Motivation:

`Buffer` currently should be used everywhere, as a contract. Currently, we should not be able to use sources which are backed by files or similar, as they could block the running thread, which is currently unacceptable.
Should be investigated further later: https://github.com/rsocket/rsocket-kotlin/issues/110